### PR TITLE
[gitops-manager] Add Makefile with all standard targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,139 @@
+# Image URL to use for all building/pushing image targets
+IMG ?= controller:latest
+# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest
+ENVTEST_K8S_VERSION = 1.31.0
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+.PHONY: all
+all: build
+
+##@ General
+
+.PHONY: help
+help: ## Print this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Development
+
+.PHONY: generate
+generate: controller-gen ## Generate DeepCopy, DeepCopyInto, and DeepCopyObject methods
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+
+.PHONY: manifests
+manifests: controller-gen ## Generate CRD, RBAC, and webhook manifests
+	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=config/rbac
+
+.PHONY: fmt
+fmt: ## Run go fmt
+	go fmt ./...
+
+.PHONY: vet
+vet: ## Run go vet
+	go vet ./...
+
+.PHONY: test
+test: manifests generate fmt vet envtest ## Run unit and integration tests with race detector
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-path $(LOCALBIN) -p path)" \
+	  go test -race ./... -coverprofile cover.out
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint
+	$(GOLANGCI_LINT) run ./...
+
+.PHONY: run
+run: manifests generate fmt vet ## Run the controller locally against ~/.kube/config
+	go run ./cmd/main.go
+
+##@ Build
+
+.PHONY: build
+build: manifests generate fmt vet ## Build the manager binary to bin/manager
+	go build -o bin/manager ./cmd/main.go
+
+.PHONY: docker-build
+docker-build: ## Build the container image (set IMG=<image>:<tag>)
+	docker build -t ${IMG} .
+
+.PHONY: docker-push
+docker-push: ## Push the container image (set IMG=<image>:<tag>)
+	docker push ${IMG}
+
+##@ Deployment
+
+ifndef ignore-not-found
+  ignore-not-found = false
+endif
+
+.PHONY: install
+install: manifests ## Install CRDs into the cluster specified by ~/.kube/config
+	kubectl apply -f config/crd/bases
+
+.PHONY: uninstall
+uninstall: manifests ## Remove CRDs from the cluster (set ignore-not-found=true to ignore missing resources)
+	kubectl delete --ignore-not-found=$(ignore-not-found) -f config/crd/bases
+
+.PHONY: deploy
+deploy: manifests ## Deploy the controller to the cluster with image substitution (set IMG=<image>:<tag>)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	$(KUSTOMIZE) build config/default | kubectl apply -f -
+
+.PHONY: undeploy
+undeploy: ## Remove the controller from the cluster
+	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+##@ Dependencies
+
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
+
+CONTROLLER_TOOLS_VERSION ?= v0.16.4
+KUSTOMIZE_VERSION ?= v5.4.3
+ENVTEST_VERSION ?= release-0.19
+GOLANGCI_LINT_VERSION ?= v1.61.0
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary
+$(CONTROLLER_GEN): $(LOCALBIN)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
+
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary
+$(KUSTOMIZE): $(LOCALBIN)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v5,$(KUSTOMIZE_VERSION))
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download setup-envtest locally if necessary
+$(ENVTEST): $(LOCALBIN)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary
+$(GOLANGCI_LINT): $(LOCALBIN)
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+
+# go-install-tool will 'go install' any package with custom variables into a local install directory
+define go-install-tool
+@[ -f "$(1)-$(3)" ] || { \
+set -e ;\
+package=$(2)@$(3) ;\
+echo "Downloading $${package}" ;\
+GOBIN=$(LOCALBIN) go install $${package} ;\
+mv "$$(echo "$(1)" | sed 's/-$(3)$$//')" $(1)-$(3) 2>/dev/null || true ;\
+} ;\
+ln -sf $(1)-$(3) $(1)
+endef

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,15 @@
+/*
+Copyright 2026 Mark Abrams.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/


### PR DESCRIPTION
## Summary

- Adds `Makefile` with all 13 standard targets required by issue #5: `generate`, `manifests`, `test`, `lint`, `build`, `docker-build`, `docker-push`, `deploy`, `undeploy`, `install`, `uninstall`, `run`, and `help`
- Adds `hack/boilerplate.go.txt` Apache 2.0 header consumed by `controller-gen object` during code generation
- Tool dependencies (controller-gen, kustomize, setup-envtest, golangci-lint) are pinned to specific versions and downloaded locally to `bin/` on first use

## Test plan

- [ ] `make help` prints all targets with descriptions
- [ ] `make generate` runs after kubebuilder scaffold (issue #1) is merged
- [ ] `make manifests` runs after kubebuilder scaffold is merged
- [ ] `make build` succeeds after Go source is in place
- [ ] `make test` runs with race detector after test suite is in place
- [ ] `make lint` runs golangci-lint without errors
- [ ] `make docker-build IMG=test:latest` builds the container image
- [ ] `make install` / `make uninstall` apply/remove CRDs against a test cluster

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)