### PR TITLE
feat(security): RBAC minimal-privilege policy and secret scanning CI

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,45 @@
+name: Security Scan
+
+# Scans for secrets and credentials on every push and PR.
+# Gitleaks checks the full git history on PRs to catch secrets in any commit,
+# not just the final diff — preventing rebased-away secrets from landing on develop/main.
+
+on:
+  push:
+    branches:
+      - develop
+      - "develop/**"
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+
+permissions:
+  contents: read
+  # Required for gitleaks to annotate PR diffs with findings
+  pull-requests: read
+
+jobs:
+  secret-scan:
+    name: Secret Scanning (Gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so gitleaks can scan all commits, not just HEAD.
+          # This catches secrets that were added and then "removed" in a later commit.
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE is required for organisation-level scans.
+          # For public repos or personal use this can be left unset.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          # Point gitleaks at the project config file so custom rules and
+          # test-fixture allowlists are respected on every run.
+          config-path: .gitleaks.toml

--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,13 @@ vendor/
 
 # kubebuilder / controller-gen generated
 config/crd/bases/
-config/rbac/role.yaml
+# config/rbac/role.yaml is committed and owned by the security persona.
+# The developer must align // +kubebuilder:rbac markers with this policy baseline
+# rather than letting controller-gen free-generate the role.
+!config/rbac/role.yaml
 !config/rbac/role_binding.yaml
 !config/rbac/service_account.yaml
+!config/rbac/gea_service_account.yaml
 
 # zz_generated files are committed (needed for builds without code-gen tools)
 # but listed here as a reminder they are auto-generated

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,48 @@
+# Gitleaks configuration for losant-device-controller
+# Scans for accidentally committed credentials, API keys, and secrets.
+# Patterns include Losant API keys, Kubernetes secrets, and common credential formats.
+
+title = "losant-device gitleaks config"
+
+[extend]
+# Extend the default ruleset shipped with gitleaks
+useDefault = true
+
+[[allowlists]]
+description = "Test fixtures with intentionally fake/placeholder keys"
+paths = [
+  # Test directories may contain example credentials that are not real
+  '''test/.*''',
+  '''.*_test\.go''',
+  # Documentation examples
+  '''docs/.*''',
+]
+regexes = [
+  # Placeholder patterns used in tests and docs
+  '''REPLACE_ME''',
+  '''YOUR_.*_HERE''',
+  '''example-.*-key''',
+  '''fake-.*-secret''',
+  '''test-access-key''',
+  '''test-access-secret''',
+]
+
+[[rules]]
+id = "losant-access-key"
+description = "Losant Access Key"
+# Losant access keys follow the pattern of a UUID-like string
+regex = '''(?i)(losant[_-]?(access[_-]?key|api[_-]?key))\s*[=:]\s*['""]?([a-f0-9-]{36,})['""]?'''
+tags = ["losant", "key", "secret"]
+
+[[rules]]
+id = "losant-access-secret"
+description = "Losant Access Secret"
+regex = '''(?i)(losant[_-]?(access[_-]?secret|secret))\s*[=:]\s*['""]?([A-Za-z0-9+/]{40,})['""]?'''
+tags = ["losant", "secret"]
+
+[[rules]]
+id = "kubernetes-secret-data"
+description = "Base64-encoded Kubernetes secret data value (high entropy)"
+# Flag base64 values in YAML secret data blocks that look like real credentials
+regex = '''(?m)^\s{2,}(ACCESS_KEY|ACCESS_SECRET|DEVICE_ID|API_KEY|TOKEN|PASSWORD|SECRET)\s*:\s*[A-Za-z0-9+/]{20,}={0,2}$'''
+tags = ["kubernetes", "secret"]

--- a/config/rbac/gea_service_account.yaml
+++ b/config/rbac/gea_service_account.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: losant-gea
+  namespace: losant-system
+  labels:
+    app.kubernetes.io/name: losant-gea
+    app.kubernetes.io/component: gateway-edge-agent
+  annotations:
+    # The GEA pod communicates outbound to Losant cloud over MQTT only.
+    # It requires no Kubernetes API permissions — automounting is explicitly disabled.
+automountServiceAccountToken: false

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: losant-device-controller-role
+  labels:
+    app.kubernetes.io/name: losant-device-controller
+    app.kubernetes.io/component: controller
+rules:
+  # HealthWatcherReconciler reads cluster topology to compute health metrics
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+
+  # HealthWatcherReconciler counts pod states per node (CrashLoopBackOff, OOMKilled, etc.)
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+
+  # pvc_collector tracks PVCs not in Bound phase
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+
+  # event_collector counts Warning events in a 1-hour sliding window
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+
+  # coredns_collector checks CoreDNS Deployment available replicas
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch"]
+
+  # LosantSyncReconciler reads Losant API credentials for device provisioning
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+
+  # LosantSyncReconciler owns the LosantSync CR and updates its status subresource
+  - apiGroups: ["losant.io"]
+    resources: ["losantsyncs"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["losant.io"]
+    resources: ["losantsyncs/status"]
+    verbs: ["get", "update", "patch"]
+
+  # controller-runtime leader election requires lease management
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: losant-device-controller-rolebinding
+  labels:
+    app.kubernetes.io/name: losant-device-controller
+    app.kubernetes.io/component: controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: losant-device-controller-role
+subjects:
+  - kind: ServiceAccount
+    name: losant-device-controller
+    namespace: losant-system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: losant-device-controller
+  namespace: losant-system
+  labels:
+    app.kubernetes.io/name: losant-device-controller
+    app.kubernetes.io/component: controller


### PR DESCRIPTION
## Summary

- **Closes #13** — Least-privilege RBAC manifests for the controller and GEA
- **Closes #14** — Gitleaks secret scanning added to CI pipeline

## Changes

### RBAC (issue #13)

| File | Description |
|---|---|
| `config/rbac/role.yaml` | ClusterRole with exact verbs per resource — no wildcards |
| `config/rbac/service_account.yaml` | Dedicated `losant-device-controller` ServiceAccount |
| `config/rbac/role_binding.yaml` | Binds ClusterRole to controller ServiceAccount |
| `config/rbac/gea_service_account.yaml` | GEA ServiceAccount with `automountServiceAccountToken: false` |
| `.gitignore` | Un-ignored `config/rbac/role.yaml` so security owns it vs controller-gen |

**Permission rationale** (each rule has an inline comment in `role.yaml`):
- `nodes/pods/pvcs/events/deployments`: `get/list/watch` — HealthWatcherReconciler collectors
- `secrets`: `get` only — LosantSyncReconciler reads credentials for provisioning
- `losantsyncs` + `losantsyncs/status`: `get/update/patch` — controller owns this CR
- `leases`: full CRUD — controller-runtime leader election

**Note for developer**: `// +kubebuilder:rbac` markers in Go code must match this policy baseline. Do not let controller-gen free-generate `role.yaml` — it is security-owned and committed.

### Secret Scanning (issue #14)

| File | Description |
|---|---|
| `.github/workflows/security-scan.yml` | Gitleaks on every push/PR with `fetch-depth: 0` |
| `.gitleaks.toml` | Extends default ruleset; Losant key/secret patterns; test fixture allowlist |

Key decisions:
- `fetch-depth: 0` — scans full git history on PRs, not just the diff, so secrets removed in later commits are still caught
- Custom rules for `losant-access-key` and `losant-access-secret` patterns
- Allowlist covers `test/**`, `*_test.go`, and `docs/**` for placeholder values

## Dependencies

- #13 depends on #4 (HealthWatcher resource list) — permissions are pre-specified from the architecture doc and issue body; developer must align kubebuilder markers with this policy
- #14 depends on #7 (CI workflow) — this is a standalone workflow; no dependency on `ci.yml` existing

## Test plan

- [ ] YAML is valid (no syntax errors)
- [ ] `role.yaml` contains no wildcard (`*`) verbs — verify with `grep '\*' config/rbac/role.yaml`
- [ ] GEA ServiceAccount has `automountServiceAccountToken: false`
- [ ] `security-scan.yml` triggers on push to `develop` and `main` and on PRs to those branches
- [ ] Gitleaks workflow uses `fetch-depth: 0`
- [ ] `.gitleaks.toml` config is referenced by the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)