### PR TITLE
[docs] Add deployment guide, Helm values reference, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ helm install losant-device helm/ \
 ```bash
 make generate      # regenerate DeepCopy methods
 make manifests     # regenerate CRD/RBAC manifests
+make build         # build controller binary to bin/manager
 make test          # run unit + integration tests
 make lint          # golangci-lint
 make run           # run controller locally against ~/.kube/config
+make docker-build  # build container image (set IMG=<image>:<tag>)
+make docker-push   # push container image (set IMG=<image>:<tag>)
 ```
 
 See [CLAUDE.md](CLAUDE.md) for agent development instructions and persona workflow rules.
@@ -116,6 +119,8 @@ See [CLAUDE.md](CLAUDE.md) for agent development instructions and persona workfl
 ## Documentation
 
 - [Architecture](docs/architecture.md) — system design, device model, controller internals
+- [Deployment](docs/deployment.md) — kustomize and Helm deployment paths, GEA manifest layout
+- [Helm Values](helm/README.md) — full reference for all Helm chart values
 - [Agent Workflow](docs/agent-workflow.md) — multi-agent branch strategy and persona rules
 - [Losant Setup](docs/losant-setup.md) — one-time Losant Application and Edge Compute device configuration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,178 @@
+# Deployment
+
+This document covers how to deploy the losant-device operator and its companion GEA pod. Two paths are supported: **kustomize** (direct manifest apply, suited for GitOps) and **Helm** (suited for parameterized installs and package distribution). Both paths result in the same running components.
+
+## Prerequisites
+
+- `kubectl` connected to a running k3s (or standard Kubernetes) cluster
+- Credentials from the [Losant setup guide](losant-setup.md)
+- `make` (for kustomize path) or `helm` v3.x (for Helm path)
+
+---
+
+## Namespace
+
+Both paths use the `losant-system` namespace. Create it first if you are not using Helm's `--create-namespace`:
+
+```bash
+kubectl create namespace losant-system
+```
+
+---
+
+## Credentials Secrets
+
+Both deployment paths expect these two secrets to exist before resources are applied.
+
+### GEA credentials
+
+The GEA pod reads these from the `losant-gea-credentials` secret at startup:
+
+```bash
+kubectl create secret generic losant-gea-credentials \
+  --from-literal=DEVICE_ID=<edge-compute-device-id> \
+  --from-literal=ACCESS_KEY=<gea-access-key> \
+  --from-literal=ACCESS_SECRET=<gea-access-secret> \
+  -n losant-system
+```
+
+### Provisioning credentials
+
+The controller uses these for Losant REST API calls (device provisioning only):
+
+```bash
+kubectl create secret generic losant-provisioning-credentials \
+  --from-literal=losant-access-key=<provisioning-key> \
+  --from-literal=losant-access-secret=<provisioning-secret> \
+  -n losant-system
+```
+
+---
+
+## Path 1: Kustomize (Makefile targets)
+
+This is the default path used in development and CI. The Makefile wraps `kubectl` and `kustomize` for each step.
+
+### Install CRDs only
+
+```bash
+make install IMG=ghcr.io/mak3r/losant-device:latest
+```
+
+Applies the `LosantSync` CRD from `config/crd/bases/` into the cluster. Safe to run repeatedly — it is idempotent.
+
+### Deploy controller + GEA
+
+```bash
+make deploy IMG=ghcr.io/mak3r/losant-device:latest
+```
+
+Sets the controller image in `config/manager/kustomization.yaml`, then applies the full `config/default` kustomization (controller Deployment, ServiceAccount, RBAC, and the GEA resources from `config/gea/`).
+
+### Remove deployment
+
+```bash
+make undeploy
+```
+
+Removes the controller and all associated resources. Does not remove CRDs or the `losant-system` namespace.
+
+### Remove CRDs
+
+```bash
+make uninstall
+```
+
+Deletes the `LosantSync` CRD. Any existing `LosantSync` CR objects will be garbage-collected.
+
+---
+
+## Path 2: Helm
+
+The `helm/` chart installs and manages the operator and GEA together. It is a skeleton for Phase 5 — full template rendering will be completed in a later phase. `helm lint helm/` passes clean.
+
+### Install
+
+```bash
+helm install losant-device helm/ \
+  --namespace losant-system \
+  --create-namespace \
+  --set gea.credentials.secretValues.deviceID=<id> \
+  --set gea.credentials.secretValues.accessKey=<key> \
+  --set gea.credentials.secretValues.accessSecret=<secret>
+```
+
+Alternatively, use an existing secret (skips inline credential values):
+
+```bash
+helm install losant-device helm/ \
+  --namespace losant-system \
+  --create-namespace \
+  --set gea.credentials.existingSecret=losant-gea-credentials
+```
+
+### Upgrade
+
+```bash
+helm upgrade losant-device helm/ --namespace losant-system
+```
+
+### Uninstall
+
+```bash
+helm uninstall losant-device --namespace losant-system
+```
+
+See [helm/README.md](../helm/README.md) for all configurable values.
+
+---
+
+## GEA Manifest Layout
+
+The `config/gea/` directory contains raw Kubernetes manifests for the Losant Gateway Edge Agent. These are included by the default kustomization and can also be applied independently:
+
+```bash
+kubectl apply -k config/gea/
+```
+
+| File | Resource | Purpose |
+|---|---|---|
+| `serviceaccount.yaml` | ServiceAccount `losant-gea` | Dedicated identity for the GEA pod; has **no** Kubernetes API permissions |
+| `pvc.yaml` | PersistentVolumeClaim `losant-gea-data` | 1Gi `ReadWriteOnce` volume for GEA's SQLite offline buffer at `/data` |
+| `deployment.yaml` | Deployment `losant-gea` | Runs `losant/edge-agent:latest`; mounts the PVC; reads credentials from `losant-gea-credentials` secret |
+| `service.yaml` | ClusterIP Service `losant-gea` | Exposes port 8080 (HTTP trigger) in-cluster; the controller POSTs metric payloads here |
+| `kustomization.yaml` | Kustomization | Declares all four resources; sets namespace `losant-system` |
+
+### GEA Deployment details
+
+The GEA Deployment (`config/gea/deployment.yaml`) configures the following:
+
+**Environment variables** (sourced from `losant-gea-credentials` secret):
+- `DEVICE_ID` — Losant Edge Compute device ID; establishes the GEA's MQTT identity
+- `ACCESS_KEY` / `ACCESS_SECRET` — Losant credentials for the MQTT connection
+
+**Volume**: `/data` is mounted from the PVC and stores the GEA's SQLite buffer, which holds up to 65,000 messages during connectivity gaps.
+
+**Probes**: Both liveness and readiness probes issue `HTTP GET /` on port 8080. The readiness probe has a 10-second initial delay; liveness has a 30-second initial delay to allow the MQTT connection to establish.
+
+**Resource limits**: 500m CPU / 512Mi memory (limits); 100m CPU / 128Mi memory (requests).
+
+**ServiceAccount**: `losant-gea` (no RBAC permissions — the GEA only communicates outbound to `broker.losant.com`).
+
+---
+
+## Apply a LosantSync CR
+
+After the controller and GEA are running, create a `LosantSync` resource to begin monitoring:
+
+```bash
+kubectl apply -f config/samples/losant_v1alpha1_losantsync.yaml
+```
+
+Watch the controller bring the resource to `Active` phase:
+
+```bash
+kubectl get losantsync -w
+```
+
+See [docs/architecture.md](architecture.md#crd-losantsync) for the full CRD field reference.

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,136 @@
+# losant-device Helm Chart
+
+Installs the losant-device Kubernetes operator and the Losant Gateway Edge Agent (GEA) into a single namespace.
+
+Chart version: `0.1.0` (skeleton — full template implementation in Phase 5).
+
+## Install
+
+```bash
+helm install losant-device helm/ \
+  --namespace losant-system \
+  --create-namespace \
+  --set gea.credentials.secretValues.deviceID=<id> \
+  --set gea.credentials.secretValues.accessKey=<key> \
+  --set gea.credentials.secretValues.accessSecret=<secret>
+```
+
+To use an existing credentials secret instead of inline values:
+
+```bash
+helm install losant-device helm/ \
+  --namespace losant-system \
+  --create-namespace \
+  --set gea.credentials.existingSecret=losant-gea-credentials
+```
+
+## Values Reference
+
+### `controller`
+
+Settings for the losant-device operator Deployment.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `controller.image.repository` | string | `ghcr.io/mak3r/losant-device` | Container image repository |
+| `controller.image.tag` | string | `latest` | Image tag |
+| `controller.image.pullPolicy` | string | `IfNotPresent` | Image pull policy (`Always`, `IfNotPresent`, `Never`) |
+| `controller.replicaCount` | integer | `1` | Number of controller replicas (>1 requires `leaderElection: true`) |
+| `controller.resources` | object | see below | CPU/memory requests and limits |
+| `controller.leaderElection` | bool | `true` | Enable leader election (required for replicaCount > 1) |
+| `controller.logLevel` | string | `info` | Log verbosity (`debug`, `info`, `warn`, `error`) |
+
+Default resources:
+```yaml
+controller:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+```
+
+### `gea`
+
+Settings for the Losant Gateway Edge Agent Deployment.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `gea.image.repository` | string | `losant/edge-agent` | GEA container image repository |
+| `gea.image.tag` | string | `latest` | Image tag |
+| `gea.image.pullPolicy` | string | `IfNotPresent` | Image pull policy |
+| `gea.service.port` | integer | `8080` | ClusterIP Service port; the controller POSTs metric payloads here |
+| `gea.storage.size` | string | `1Gi` | Size of the PVC used for the GEA's SQLite offline buffer |
+| `gea.storage.storageClassName` | string | `""` | StorageClass for the PVC; empty string uses the cluster default |
+| `gea.resources` | object | see below | CPU/memory requests and limits |
+| `gea.credentials.existingSecret` | string | `""` | Name of an existing Secret containing `DEVICE_ID`, `ACCESS_KEY`, `ACCESS_SECRET`. When set, `secretValues` is ignored. |
+| `gea.credentials.secretValues.deviceID` | string | `""` | Losant Edge Compute device ID (creates a new Secret; ignored if `existingSecret` is set) |
+| `gea.credentials.secretValues.accessKey` | string | `""` | Losant access key (creates a new Secret; ignored if `existingSecret` is set) |
+| `gea.credentials.secretValues.accessSecret` | string | `""` | Losant access secret (creates a new Secret; ignored if `existingSecret` is set) |
+
+Default resources:
+```yaml
+gea:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+```
+
+#### Credentials: `existingSecret` vs `secretValues`
+
+Use `existingSecret` when the credentials secret is managed outside Helm (e.g., by Vault, External Secrets Operator, or `kubectl create secret`). This avoids storing sensitive values in Helm release history.
+
+Use `secretValues` for quick installs or when Helm manages the full release lifecycle. The chart creates the secret from these values and owns it on `helm uninstall`.
+
+### `rbac`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `rbac.create` | bool | `true` | Create the ClusterRole and ClusterRoleBinding for the controller |
+
+Set to `false` if your cluster uses an external RBAC management system and you will apply the role manifests separately.
+
+### `serviceAccount`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `serviceAccount.create` | bool | `true` | Create a dedicated ServiceAccount for the controller |
+| `serviceAccount.annotations` | object | `{}` | Annotations to add to the ServiceAccount (e.g., for IRSA or Workload Identity) |
+
+### `namespace`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `namespace.create` | bool | `true` | Create the target namespace |
+| `namespace.name` | string | `losant-system` | Namespace to deploy into |
+
+## Required Values
+
+`controller.image.repository` and `gea.image.repository` are required by the schema. All other values have defaults.
+
+At least one of `gea.credentials.existingSecret` or non-empty `gea.credentials.secretValues.*` must be provided for the GEA pod to authenticate to Losant.
+
+## Upgrading
+
+```bash
+helm upgrade losant-device helm/ --namespace losant-system
+```
+
+## Uninstalling
+
+```bash
+helm uninstall losant-device --namespace losant-system
+```
+
+Note: CRDs and the `LosantSync` CRs are not removed by `helm uninstall`. Delete them manually if needed:
+
+```bash
+kubectl delete losantsyncs --all
+kubectl delete crd losantsyncs.losant.io
+```


### PR DESCRIPTION
## Summary

- **`docs/deployment.md`** (new): end-to-end deployment guide covering both kustomize (`make install` / `make deploy`) and Helm paths; documents the `config/gea/` manifest layout with per-resource detail (ServiceAccount, PVC, Deployment, Service, kustomization); explains credential secret setup and GEA probe/resource configuration
- **`helm/README.md`** (new): full values reference for all `controller.*`, `gea.*`, `rbac.*`, `serviceAccount.*`, and `namespace.*` keys; explains the `existingSecret` vs `secretValues` credential strategy and upgrade/uninstall steps
- **`README.md`** (updated): adds `make build`, `docker-build`, `docker-push` to the Development section; adds Deployment and Helm Values entries to the Documentation index

## Dependency

This PR documents resources introduced in PR #26 (`config/gea/`, `helm/`, CI workflows). It should merge **after** #26 lands on `develop`. The docs themselves are self-consistent and do not import any code.

## Test plan

- [ ] `docs/deployment.md` renders correctly in GitHub markdown preview
- [ ] `helm/README.md` renders correctly; values table matches `helm/values.yaml` after #26 merges
- [ ] README documentation links are not broken after both PRs merge

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)