### PR TITLE
[developer] Implement LosantClient and GEAClient interfaces

### DIFF
--- a/internal/gea/client.go
+++ b/internal/gea/client.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gea
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
+)
+
+// GEAClient sends metric state payloads to the in-cluster Losant Gateway Edge Agent.
+type GEAClient interface {
+	// ReportState delivers a device state payload to the GEA for buffering and MQTT forwarding.
+	ReportState(ctx context.Context, payload StatePayload) error
+}
+
+// StatePayload carries the metric snapshot for a single Losant device.
+type StatePayload struct {
+	// DeviceID is the Losant peripheral or edge-compute device receiving this state.
+	DeviceID string
+
+	// Attributes maps Losant attribute names to their current values.
+	Attributes map[string]interface{}
+
+	// Timestamp is the observation time. If nil, the GEA applies its own clock.
+	Timestamp *time.Time
+}
+
+// geaStateBody is the JSON wire format expected by the GEA HTTP trigger.
+type geaStateBody struct {
+	DeviceID string                 `json:"deviceId"`
+	Time     *time.Time             `json:"time,omitempty"`
+	Data     map[string]interface{} `json:"data"`
+}
+
+// HTTPClient implements GEAClient by POSTing to the in-cluster GEA service.
+type HTTPClient struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// NewHTTPClient constructs a GEA HTTPClient from a GEASpec.
+// The endpoint is resolved as http://{spec.ServiceRef}:{spec.Port}/state.
+func NewHTTPClient(spec losantv1alpha1.GEASpec) *HTTPClient {
+	return &HTTPClient{
+		endpoint:   fmt.Sprintf("http://%s:%d/state", spec.ServiceRef, spec.Port),
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// ReportState marshals the payload and POSTs it to the GEA trigger endpoint.
+func (c *HTTPClient) ReportState(ctx context.Context, payload StatePayload) error {
+	wire := geaStateBody{
+		DeviceID: payload.DeviceID,
+		Time:     payload.Timestamp,
+		Data:     payload.Attributes,
+	}
+
+	b, err := json.Marshal(wire)
+	if err != nil {
+		return fmt.Errorf("marshal state payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("build gea request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("gea post %s: %w", c.endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("gea post %s: status %d: %s", c.endpoint, resp.StatusCode, body)
+	}
+	return nil
+}

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package losant
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
+)
+
+const (
+	apiBase         = "https://api.losant.com"
+	deviceClassEdge = "edgeCompute"
+	deviceClassNode = "peripheral"
+)
+
+// LosantClient manages Losant device lifecycle via the REST provisioning API.
+type LosantClient interface {
+	// EnsureClusterDevice creates or retrieves the Edge Compute device representing this cluster.
+	EnsureClusterDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (deviceID string, err error)
+
+	// EnsureNodeDevice creates or retrieves the peripheral device for a k8s node.
+	EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (deviceID string, err error)
+
+	// UpdateDeviceTags replaces the tag set on an existing Losant device.
+	UpdateDeviceTags(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
+
+	// GetDevice returns the current definition of a Losant device.
+	GetDevice(ctx context.Context, applicationID, deviceID string) (*Device, error)
+}
+
+// Device is a minimal Losant device representation sufficient for the provisioning workflow.
+type Device struct {
+	DeviceID string `json:"deviceId"`
+	Name     string `json:"name"`
+	Tags     []Tag  `json:"tags"`
+}
+
+// Tag is a Losant key-value tag attached to a device.
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// HTTPClient implements LosantClient using the Losant REST API.
+type HTTPClient struct {
+	token      string
+	httpClient *http.Client
+}
+
+// NewHTTPClient constructs an HTTPClient from a provisioning Secret.
+// The Secret must contain the key "access-key" whose value is a Losant Application API Token.
+// The optional "access-secret" field is accepted for future HMAC auth support but unused today.
+func NewHTTPClient(secret *corev1.Secret) (*HTTPClient, error) {
+	token, ok := secret.Data["access-key"]
+	if !ok {
+		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"access-key\"",
+			secret.Namespace, secret.Name)
+	}
+	return &HTTPClient{
+		token:      string(token),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+// EnsureClusterDevice looks up the cluster Edge Compute device by name and creates it if absent.
+func (c *HTTPClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error) {
+	name := clusterDeviceName(spec.ClusterName)
+	existing, err := c.findDeviceByName(ctx, spec.ApplicationID, name)
+	if err != nil {
+		return "", err
+	}
+	if existing != nil {
+		return existing.DeviceID, nil
+	}
+
+	tags := tagsFromSpec(spec)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, tags)
+}
+
+// EnsureNodeDevice looks up the peripheral device for a node by name and creates it if absent.
+func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error) {
+	name := nodeDeviceName(spec.ClusterName, nodeName)
+	existing, err := c.findDeviceByName(ctx, spec.ApplicationID, name)
+	if err != nil {
+		return "", err
+	}
+	if existing != nil {
+		return existing.DeviceID, nil
+	}
+
+	tags := tagsFromSpec(spec)
+	tags = append(tags, Tag{Key: "nodeName", Value: nodeName})
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, tags)
+}
+
+// UpdateDeviceTags replaces the tags on the given device.
+func (c *HTTPClient) UpdateDeviceTags(ctx context.Context, applicationID, deviceID string, tags map[string]string) error {
+	tagList := make([]Tag, 0, len(tags))
+	for k, v := range tags {
+		tagList = append(tagList, Tag{Key: k, Value: v})
+	}
+
+	payload := map[string]interface{}{"tags": tagList}
+	path := fmt.Sprintf("%s/applications/%s/devices/%s", apiBase, applicationID, deviceID)
+	_, err := c.doRequest(ctx, http.MethodPatch, path, payload)
+	return err
+}
+
+// GetDevice returns the current Losant device definition.
+func (c *HTTPClient) GetDevice(ctx context.Context, applicationID, deviceID string) (*Device, error) {
+	path := fmt.Sprintf("%s/applications/%s/devices/%s", apiBase, applicationID, deviceID)
+	body, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var dev Device
+	if err := json.Unmarshal(body, &dev); err != nil {
+		return nil, fmt.Errorf("decode device response: %w", err)
+	}
+	return &dev, nil
+}
+
+// findDeviceByName returns the first Losant device matching name, or nil if not found.
+func (c *HTTPClient) findDeviceByName(ctx context.Context, applicationID, name string) (*Device, error) {
+	path := fmt.Sprintf("%s/applications/%s/devices?filterField=name&filter=%s",
+		apiBase, applicationID, url.QueryEscape(name))
+	body, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Items []Device `json:"items"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode device list response: %w", err)
+	}
+	if len(result.Items) == 0 {
+		return nil, nil
+	}
+	return &result.Items[0], nil
+}
+
+// createDevice POSTs a new device and returns the assigned device ID.
+func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID string, tags []Tag) (string, error) {
+	payload := map[string]interface{}{
+		"name":        name,
+		"deviceClass": class,
+		"tags":        tags,
+	}
+	if recipeID != "" {
+		payload["deviceRecipeId"] = recipeID
+	}
+
+	path := fmt.Sprintf("%s/applications/%s/devices", apiBase, applicationID)
+	body, err := c.doRequest(ctx, http.MethodPost, path, payload)
+	if err != nil {
+		return "", err
+	}
+
+	var dev Device
+	if err := json.Unmarshal(body, &dev); err != nil {
+		return "", fmt.Errorf("decode create device response: %w", err)
+	}
+	if dev.DeviceID == "" {
+		return "", fmt.Errorf("create device: empty deviceId in response")
+	}
+	return dev.DeviceID, nil
+}
+
+// doRequest executes an authenticated HTTP request and returns the response body.
+func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload interface{}) ([]byte, error) {
+	var body io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request payload: %w", err)
+		}
+		body = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, path, body)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("losant api %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("losant api %s %s: status %d: %s", method, path, resp.StatusCode, respBody)
+	}
+	return respBody, nil
+}
+
+// clusterDeviceName returns the canonical Losant device name for a cluster.
+func clusterDeviceName(clusterName string) string {
+	return fmt.Sprintf("k8s-cluster-%s", clusterName)
+}
+
+// nodeDeviceName returns the canonical Losant device name for a node within a cluster.
+func nodeDeviceName(clusterName, nodeName string) string {
+	return fmt.Sprintf("k8s-node-%s-%s", clusterName, nodeName)
+}
+
+// tagsFromSpec builds the base tag list from the LosantSyncSpec fields.
+func tagsFromSpec(spec losantv1alpha1.LosantSyncSpec) []Tag {
+	tags := []Tag{
+		{Key: "clusterName", Value: spec.ClusterName},
+		{Key: "region", Value: spec.Region},
+	}
+	if spec.RancherURL != "" {
+		tags = append(tags, Tag{Key: "rancherURL", Value: spec.RancherURL})
+	}
+	return tags
+}


### PR DESCRIPTION
## Summary

- Adds `internal/losant/client.go`: `LosantClient` interface (`EnsureClusterDevice`, `EnsureNodeDevice`, `UpdateDeviceTags`, `GetDevice`) with concrete `HTTPClient` backed by the Losant REST API; credentials read from a `corev1.Secret` via `access-key` field
- Adds `internal/gea/client.go`: `GEAClient` interface (`ReportState`) with concrete `HTTPClient` that POSTs `StatePayload` to `http://{spec.ServiceRef}:{spec.Port}/state`; both interfaces are mockable for the test-engineer

Closes #33, closes #34

## Test plan
- [ ] `go build ./...` passes (verified locally before commit)
- [ ] Test-engineer can now write `internal/losant/mock_client.go` and `internal/gea/mock_client.go` implementing the respective interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)