### PR TITLE
[developer] Align RBAC markers with security-approved role.yaml

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -36,9 +36,9 @@ type LosantSyncReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=losant.io,resources=losantsyncs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=losant.io,resources=losantsyncs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=losant.io,resources=losantsyncs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch


### PR DESCRIPTION
## Summary

- Removes `create;delete` from the `losantsyncs` marker — `LosantSyncReconciler` only reconciles, never creates or deletes `LosantSync` CRs
- Removes `losantsyncs/finalizers` marker — finalizers are not used by this controller and the verb was not in `config/rbac/role.yaml`
- Adds `coordination.k8s.io/leases` marker — required for leader election and already present in `role.yaml`

Closes #30

## Remaining gap (tracked separately)

Security issue #39 documents that `role.yaml` is still missing `list;watch` on `losantsyncs`. These verbs are required by controller-runtime's informer cache and cannot be removed from the marker without breaking the controller. The security persona must update `role.yaml` before the controller can function in a cluster.

## Test plan
- [ ] `go build ./...` passes (verified locally)
- [ ] `grep kubebuilder:rbac internal/controller/*.go` output manually diffed against `config/rbac/role.yaml` — see PR description

🤖 Generated with [Claude Code](https://claude.com/claude-code)