### PR TITLE
feat: LosantClient + GEAClient implementations and mocks (closes #33, #34, #11, #12)

### DIFF
--- a/internal/gea/mock_client.go
+++ b/internal/gea/mock_client.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gea
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// MockClient implements GEAClient for use in unit tests.
+// It captures every ReportState call for later assertion and can be
+// configured to return errors to simulate an unreachable GEA.
+//
+// MockClient is safe for concurrent use.
+type MockClient struct {
+	mu sync.Mutex
+
+	ReportStateFunc func(ctx context.Context, payload StatePayload) error
+
+	// Calls records every ReportState invocation in order.
+	Calls []StatePayload
+}
+
+// NewMockClient returns a MockClient that accepts all payloads without error.
+func NewMockClient() *MockClient {
+	return &MockClient{}
+}
+
+// SetError configures ReportState to always return err.
+// Pass nil to revert to the default (accept all).
+func (m *MockClient) SetError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err == nil {
+		m.ReportStateFunc = nil
+		return
+	}
+	m.ReportStateFunc = func(_ context.Context, _ StatePayload) error {
+		return err
+	}
+}
+
+// Reset clears all recorded calls and resets ReportStateFunc to the default.
+func (m *MockClient) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ReportStateFunc = nil
+	m.Calls = nil
+}
+
+// CallCount returns the number of ReportState calls recorded.
+func (m *MockClient) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Calls)
+}
+
+// ReportState implements GEAClient.
+func (m *MockClient) ReportState(ctx context.Context, payload StatePayload) error {
+	m.mu.Lock()
+	m.Calls = append(m.Calls, payload)
+	fn := m.ReportStateFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, payload)
+	}
+	return nil
+}
+
+// AssertPayloadContains asserts that at least one recorded call targeted deviceID
+// and contained an attribute key with the given value.
+// Calls t.Errorf (non-fatal) on failure so the test can continue.
+func (m *MockClient) AssertPayloadContains(t *testing.T, deviceID, attributeKey string, want interface{}) {
+	t.Helper()
+	m.mu.Lock()
+	calls := make([]StatePayload, len(m.Calls))
+	copy(calls, m.Calls)
+	m.mu.Unlock()
+
+	for _, c := range calls {
+		if c.DeviceID != deviceID {
+			continue
+		}
+		got, ok := c.Attributes[attributeKey]
+		if !ok {
+			continue
+		}
+		if fmt.Sprintf("%v", got) == fmt.Sprintf("%v", want) {
+			return
+		}
+	}
+	t.Errorf("no ReportState call found for deviceID=%q with attribute %q=%v (recorded %d calls)",
+		deviceID, attributeKey, want, len(calls))
+}
+
+// AssertCalled asserts that ReportState was called at least once.
+func (m *MockClient) AssertCalled(t *testing.T) {
+	t.Helper()
+	if m.CallCount() == 0 {
+		t.Error("expected at least one ReportState call, got none")
+	}
+}
+
+// AssertNotCalled asserts that ReportState was never called.
+func (m *MockClient) AssertNotCalled(t *testing.T) {
+	t.Helper()
+	if n := m.CallCount(); n > 0 {
+		t.Errorf("expected no ReportState calls, got %d", n)
+	}
+}

--- a/internal/gea/mock_client_test.go
+++ b/internal/gea/mock_client_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gea
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+var ctx = context.Background()
+
+func TestMockClient_DefaultAcceptsAll(t *testing.T) {
+	m := NewMockClient()
+	err := m.ReportState(ctx, StatePayload{
+		DeviceID:   "dev-1",
+		Attributes: map[string]interface{}{"health_score": 95},
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if m.CallCount() != 1 {
+		t.Errorf("CallCount: got %d, want 1", m.CallCount())
+	}
+}
+
+func TestMockClient_SetError(t *testing.T) {
+	m := NewMockClient()
+	want := errors.New("gea unavailable")
+	m.SetError(want)
+
+	err := m.ReportState(ctx, StatePayload{DeviceID: "dev-1"})
+	if !errors.Is(err, want) {
+		t.Errorf("got %v, want %v", err, want)
+	}
+	// Calls are still recorded even when returning an error.
+	if m.CallCount() != 1 {
+		t.Errorf("CallCount after error: got %d, want 1", m.CallCount())
+	}
+}
+
+func TestMockClient_SetErrorNilRestoresDefault(t *testing.T) {
+	m := NewMockClient()
+	m.SetError(errors.New("down"))
+	m.SetError(nil)
+
+	if err := m.ReportState(ctx, StatePayload{DeviceID: "d"}); err != nil {
+		t.Errorf("after SetError(nil): got error %v", err)
+	}
+}
+
+func TestMockClient_AssertPayloadContains(t *testing.T) {
+	m := NewMockClient()
+	m.ReportState(ctx, StatePayload{
+		DeviceID: "dev-cluster",
+		Attributes: map[string]interface{}{
+			"health_score": 87,
+			"ready_nodes":  3,
+		},
+	})
+	m.ReportState(ctx, StatePayload{
+		DeviceID: "dev-node-1",
+		Attributes: map[string]interface{}{
+			"health_score": 100,
+		},
+	})
+
+	// Use a recorder to capture any test failures from the helper itself.
+	sub := &testing.T{}
+	m.AssertPayloadContains(sub, "dev-cluster", "health_score", 87)
+	if sub.Failed() {
+		t.Error("AssertPayloadContains: expected pass for matching attribute")
+	}
+
+	sub2 := &testing.T{}
+	m.AssertPayloadContains(sub2, "dev-cluster", "health_score", 50)
+	if !sub2.Failed() {
+		t.Error("AssertPayloadContains: expected failure for wrong value")
+	}
+
+	sub3 := &testing.T{}
+	m.AssertPayloadContains(sub3, "dev-missing", "health_score", 87)
+	if !sub3.Failed() {
+		t.Error("AssertPayloadContains: expected failure for unknown deviceID")
+	}
+}
+
+func TestMockClient_AssertCalled(t *testing.T) {
+	m := NewMockClient()
+
+	sub := &testing.T{}
+	m.AssertCalled(sub)
+	if !sub.Failed() {
+		t.Error("AssertCalled: expected failure when no calls recorded")
+	}
+
+	m.ReportState(ctx, StatePayload{DeviceID: "d"})
+	sub2 := &testing.T{}
+	m.AssertCalled(sub2)
+	if sub2.Failed() {
+		t.Error("AssertCalled: expected pass after one call")
+	}
+}
+
+func TestMockClient_AssertNotCalled(t *testing.T) {
+	m := NewMockClient()
+
+	sub := &testing.T{}
+	m.AssertNotCalled(sub)
+	if sub.Failed() {
+		t.Error("AssertNotCalled: expected pass when no calls recorded")
+	}
+
+	m.ReportState(ctx, StatePayload{DeviceID: "d"})
+	sub2 := &testing.T{}
+	m.AssertNotCalled(sub2)
+	if !sub2.Failed() {
+		t.Error("AssertNotCalled: expected failure after one call")
+	}
+}
+
+func TestMockClient_Reset(t *testing.T) {
+	m := NewMockClient()
+	m.SetError(errors.New("err"))
+	m.ReportState(ctx, StatePayload{DeviceID: "d"})
+
+	m.Reset()
+	if m.CallCount() != 0 {
+		t.Errorf("after Reset: CallCount = %d, want 0", m.CallCount())
+	}
+	if err := m.ReportState(ctx, StatePayload{DeviceID: "d"}); err != nil {
+		t.Errorf("after Reset: unexpected error %v", err)
+	}
+}
+
+func TestMockClient_ConcurrentAccess(t *testing.T) {
+	m := NewMockClient()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.ReportState(ctx, StatePayload{DeviceID: "d", Attributes: map[string]interface{}{"k": 1}})
+		}()
+	}
+	wg.Wait()
+	if m.CallCount() != 20 {
+		t.Errorf("concurrent calls: got %d, want 20", m.CallCount())
+	}
+}
+
+func TestMockClient_CustomHandlerFunc(t *testing.T) {
+	m := NewMockClient()
+	var seen []string
+	m.ReportStateFunc = func(_ context.Context, p StatePayload) error {
+		seen = append(seen, p.DeviceID)
+		return nil
+	}
+
+	m.ReportState(ctx, StatePayload{DeviceID: "dev-a"})
+	m.ReportState(ctx, StatePayload{DeviceID: "dev-b"})
+
+	if len(seen) != 2 || seen[0] != "dev-a" || seen[1] != "dev-b" {
+		t.Errorf("custom handler: got %v, want [dev-a dev-b]", seen)
+	}
+}

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package losant
+
+import (
+	"context"
+	"sync"
+
+	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
+)
+
+// MockClient implements LosantClient for use in unit tests.
+// All methods are configurable: set a HandlerFunc to override the default
+// (which returns a deterministic ID and no error). Call counts and arguments
+// are recorded and can be inspected after the fact.
+//
+// MockClient is safe for concurrent use.
+type MockClient struct {
+	mu sync.Mutex
+
+	EnsureClusterDeviceFunc func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error)
+	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error)
+	UpdateDeviceTagsFunc    func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
+	GetDeviceFunc           func(ctx context.Context, applicationID, deviceID string) (*Device, error)
+
+	// Recorded calls — read after test assertions.
+	EnsureClusterDeviceCalls []EnsureClusterDeviceCall
+	EnsureNodeDeviceCalls    []EnsureNodeDeviceCall
+	UpdateDeviceTagsCalls    []UpdateDeviceTagsCall
+	GetDeviceCalls           []GetDeviceCall
+}
+
+// EnsureClusterDeviceCall records one invocation of EnsureClusterDevice.
+type EnsureClusterDeviceCall struct {
+	Spec losantv1alpha1.LosantSyncSpec
+}
+
+// EnsureNodeDeviceCall records one invocation of EnsureNodeDevice.
+type EnsureNodeDeviceCall struct {
+	Spec     losantv1alpha1.LosantSyncSpec
+	NodeName string
+}
+
+// UpdateDeviceTagsCall records one invocation of UpdateDeviceTags.
+type UpdateDeviceTagsCall struct {
+	ApplicationID string
+	DeviceID      string
+	Tags          map[string]string
+}
+
+// GetDeviceCall records one invocation of GetDevice.
+type GetDeviceCall struct {
+	ApplicationID string
+	DeviceID      string
+}
+
+// NewMockClient returns a MockClient with sensible defaults:
+// EnsureClusterDevice returns "mock-cluster-device-id"
+// EnsureNodeDevice returns "mock-node-<nodeName>"
+// UpdateDeviceTags and GetDevice return nil error / empty Device.
+func NewMockClient() *MockClient {
+	return &MockClient{}
+}
+
+// SetError configures all methods to return err, regardless of their HandlerFuncs.
+// Useful to simulate a completely unavailable Losant API.
+func (m *MockClient) SetError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.EnsureClusterDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec) (string, error) {
+		return "", err
+	}
+	m.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _ string) (string, error) {
+		return "", err
+	}
+	m.UpdateDeviceTagsFunc = func(_ context.Context, _, _ string, _ map[string]string) error {
+		return err
+	}
+	m.GetDeviceFunc = func(_ context.Context, _, _ string) (*Device, error) {
+		return nil, err
+	}
+}
+
+// CallCount returns the total number of calls recorded across all methods.
+func (m *MockClient) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.EnsureClusterDeviceCalls) +
+		len(m.EnsureNodeDeviceCalls) +
+		len(m.UpdateDeviceTagsCalls) +
+		len(m.GetDeviceCalls)
+}
+
+// Reset clears all recorded calls and resets all HandlerFuncs to defaults.
+func (m *MockClient) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.EnsureClusterDeviceFunc = nil
+	m.EnsureNodeDeviceFunc = nil
+	m.UpdateDeviceTagsFunc = nil
+	m.GetDeviceFunc = nil
+	m.EnsureClusterDeviceCalls = nil
+	m.EnsureNodeDeviceCalls = nil
+	m.UpdateDeviceTagsCalls = nil
+	m.GetDeviceCalls = nil
+}
+
+// EnsureClusterDevice implements LosantClient.
+func (m *MockClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error) {
+	m.mu.Lock()
+	m.EnsureClusterDeviceCalls = append(m.EnsureClusterDeviceCalls, EnsureClusterDeviceCall{Spec: spec})
+	fn := m.EnsureClusterDeviceFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, spec)
+	}
+	return "mock-cluster-device-id", nil
+}
+
+// EnsureNodeDevice implements LosantClient.
+func (m *MockClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error) {
+	m.mu.Lock()
+	m.EnsureNodeDeviceCalls = append(m.EnsureNodeDeviceCalls, EnsureNodeDeviceCall{Spec: spec, NodeName: nodeName})
+	fn := m.EnsureNodeDeviceFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, spec, nodeName)
+	}
+	return "mock-node-" + nodeName, nil
+}
+
+// UpdateDeviceTags implements LosantClient.
+func (m *MockClient) UpdateDeviceTags(ctx context.Context, applicationID, deviceID string, tags map[string]string) error {
+	m.mu.Lock()
+	m.UpdateDeviceTagsCalls = append(m.UpdateDeviceTagsCalls, UpdateDeviceTagsCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+		Tags:          tags,
+	})
+	fn := m.UpdateDeviceTagsFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID, tags)
+	}
+	return nil
+}
+
+// GetDevice implements LosantClient.
+func (m *MockClient) GetDevice(ctx context.Context, applicationID, deviceID string) (*Device, error) {
+	m.mu.Lock()
+	m.GetDeviceCalls = append(m.GetDeviceCalls, GetDeviceCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+	})
+	fn := m.GetDeviceFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID)
+	}
+	return &Device{DeviceID: deviceID}, nil
+}

--- a/internal/losant/mock_client_test.go
+++ b/internal/losant/mock_client_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package losant
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
+)
+
+var ctx = context.Background()
+
+var baseSpec = losantv1alpha1.LosantSyncSpec{
+	ApplicationID: "app-123",
+	ClusterName:   "test-cluster",
+	Region:        "us-east",
+}
+
+func TestMockClient_DefaultResponses(t *testing.T) {
+	m := NewMockClient()
+
+	id, err := m.EnsureClusterDevice(ctx, baseSpec)
+	if err != nil || id == "" {
+		t.Errorf("EnsureClusterDevice: got (%q, %v), want non-empty id and nil err", id, err)
+	}
+
+	nodeID, err := m.EnsureNodeDevice(ctx, baseSpec, "node-1")
+	if err != nil || nodeID == "" {
+		t.Errorf("EnsureNodeDevice: got (%q, %v), want non-empty id and nil err", nodeID, err)
+	}
+	if nodeID != "mock-node-node-1" {
+		t.Errorf("EnsureNodeDevice default id: got %q, want %q", nodeID, "mock-node-node-1")
+	}
+
+	if err := m.UpdateDeviceTags(ctx, "app-123", "dev-1", map[string]string{"k": "v"}); err != nil {
+		t.Errorf("UpdateDeviceTags: unexpected error: %v", err)
+	}
+
+	dev, err := m.GetDevice(ctx, "app-123", "dev-1")
+	if err != nil || dev == nil {
+		t.Errorf("GetDevice: got (%v, %v), want non-nil device and nil err", dev, err)
+	}
+}
+
+func TestMockClient_CallsRecorded(t *testing.T) {
+	m := NewMockClient()
+
+	m.EnsureClusterDevice(ctx, baseSpec)
+	m.EnsureNodeDevice(ctx, baseSpec, "node-a")
+	m.EnsureNodeDevice(ctx, baseSpec, "node-b")
+	m.UpdateDeviceTags(ctx, "app-123", "dev-1", nil)
+	m.GetDevice(ctx, "app-123", "dev-1")
+
+	if len(m.EnsureClusterDeviceCalls) != 1 {
+		t.Errorf("EnsureClusterDeviceCalls: got %d, want 1", len(m.EnsureClusterDeviceCalls))
+	}
+	if len(m.EnsureNodeDeviceCalls) != 2 {
+		t.Errorf("EnsureNodeDeviceCalls: got %d, want 2", len(m.EnsureNodeDeviceCalls))
+	}
+	if m.EnsureNodeDeviceCalls[0].NodeName != "node-a" {
+		t.Errorf("first node call: got %q, want %q", m.EnsureNodeDeviceCalls[0].NodeName, "node-a")
+	}
+	if m.CallCount() != 5 {
+		t.Errorf("CallCount: got %d, want 5", m.CallCount())
+	}
+}
+
+func TestMockClient_SetError(t *testing.T) {
+	m := NewMockClient()
+	want := errors.New("api down")
+	m.SetError(want)
+
+	if _, err := m.EnsureClusterDevice(ctx, baseSpec); !errors.Is(err, want) {
+		t.Errorf("EnsureClusterDevice: got %v, want %v", err, want)
+	}
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "n"); !errors.Is(err, want) {
+		t.Errorf("EnsureNodeDevice: got %v, want %v", err, want)
+	}
+	if err := m.UpdateDeviceTags(ctx, "", "", nil); !errors.Is(err, want) {
+		t.Errorf("UpdateDeviceTags: got %v, want %v", err, want)
+	}
+	if _, err := m.GetDevice(ctx, "", ""); !errors.Is(err, want) {
+		t.Errorf("GetDevice: got %v, want %v", err, want)
+	}
+}
+
+func TestMockClient_CustomHandlerFunc(t *testing.T) {
+	m := NewMockClient()
+	m.EnsureClusterDeviceFunc = func(_ context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error) {
+		return "custom-" + spec.ClusterName, nil
+	}
+
+	id, err := m.EnsureClusterDevice(ctx, baseSpec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "custom-test-cluster" {
+		t.Errorf("got %q, want %q", id, "custom-test-cluster")
+	}
+}
+
+func TestMockClient_Reset(t *testing.T) {
+	m := NewMockClient()
+	m.EnsureClusterDevice(ctx, baseSpec)
+	m.SetError(errors.New("err"))
+	m.Reset()
+
+	if m.CallCount() != 0 {
+		t.Errorf("after Reset: CallCount = %d, want 0", m.CallCount())
+	}
+	// Default handler restored — should not error.
+	if _, err := m.EnsureClusterDevice(ctx, baseSpec); err != nil {
+		t.Errorf("after Reset: EnsureClusterDevice returned error: %v", err)
+	}
+}
+
+func TestMockClient_ConcurrentAccess(t *testing.T) {
+	m := NewMockClient()
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			m.EnsureNodeDevice(ctx, baseSpec, "node")
+		}(i)
+	}
+	wg.Wait()
+	if len(m.EnsureNodeDeviceCalls) != 20 {
+		t.Errorf("concurrent calls: got %d, want 20", len(m.EnsureNodeDeviceCalls))
+	}
+}


### PR DESCRIPTION
## Summary

Paired implementation + tests per the test-engineer pairing model. Both personas pushed to `feature/developer/clients` and all tests pass.

### Developer (commits 1–2)
- `internal/losant/client.go` — `LosantClient` interface + `HTTPClient` backed by Losant REST API; authenticates via Application API Token from `corev1.Secret`
- `internal/gea/client.go` — `GEAClient` interface + `HTTPClient` that POSTs `StatePayload` to the in-cluster GEA service

### Test Engineer (commits 3–4)
- `internal/losant/mock_client.go` — `MockClient` implements `LosantClient`; per-method `HandlerFunc` overrides, thread-safe call recording, `SetError()` for API-down simulation
- `internal/losant/mock_client_test.go` — 6 tests: defaults, call recording, error injection, custom handler, reset, concurrent access
- `internal/gea/mock_client.go` — `MockClient` implements `GEAClient`; captures `StatePayload`s, `AssertPayloadContains(t, deviceID, key, value)`, `AssertCalled/NotCalled` helpers
- `internal/gea/mock_client_test.go` — 9 tests: defaults, error injection, payload assertions, concurrent access

## Test results

```
ok  github.com/mak3r/losant-device/internal/losant  (6 tests)
ok  github.com/mak3r/losant-device/internal/gea     (9 tests)
ok  github.com/mak3r/losant-device/internal/monitor (35 tests)
ok  github.com/mak3r/losant-device/test/testenv     (passing)
```

## Notes for merge manager

- Makefile `--bin-dir` fix (issue #22) is already merged — `make test` should work
- The `access-key` secret field holds an Application API Token (single Bearer token); `access-secret` is accepted but unused today — see issue #41 for the auth investigation findings

Closes #33, #34, #11, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)