### PR TITLE
[docs] RBAC marker policy and permission-request process (issue #35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,24 @@ make uninstall     # Remove CRDs only
 
 **HealthStore**: A shared in-memory struct (RWMutex-protected) written by `HealthWatcherReconciler` and read by `LosantSyncReconciler`. Decouples k8s event processing from Losant API calls.
 
+## RBAC Policy
+
+`config/rbac/role.yaml` is **security-owned**. The security persona is the only persona that commits changes to it.
+
+### `// +kubebuilder:rbac` marker rules
+
+The developer adds `// +kubebuilder:rbac` markers in Go files so that `make manifests` can regenerate `role.yaml`. Two hard rules govern these markers:
+
+1. **Markers must not exceed the security-approved baseline.** Never add a verb to a marker that is not already present in `config/rbac/role.yaml`. Adding an unapproved verb will cause `make manifests` to silently overwrite the security-approved file with a broader role.
+
+2. **To request a new permission**, open a GitHub issue labeled `persona/security` and `type/security` first. The security persona reviews and approves the addition by updating `role.yaml`. Only after that approval may the developer add the corresponding marker.
+
+### `make manifests` and `role.yaml`
+
+`make manifests` (and `make test`, which calls it) will regenerate `config/rbac/role.yaml` from the current markers. If the markers are correctly aligned with the security-approved baseline, the regenerated content is semantically identical to the committed file — but controller-gen may produce different YAML formatting (inline vs. block style). Do not commit the regenerated file without security persona review; restore it with `git checkout config/rbac/role.yaml` if `git diff` shows only formatting changes.
+
+CI does not automatically guard against drift in `role.yaml`. Treat any unexpected `git diff` on that file after running `make manifests` as a signal to check with the security persona.
+
 ## Critical Files
 
 Changing these files has broad impact — coordinate with other personas before modifying:
@@ -101,6 +119,7 @@ Changing these files has broad impact — coordinate with other personas before 
 - `internal/losant/client.go` — REST client interface; provisioner depends on this
 - `internal/gea/client.go` — GEA HTTP client interface; controller depends on this
 - `internal/controller/losantsync_controller.go` — main reconcile loop
+- `config/rbac/role.yaml` — security-owned; see RBAC Policy above
 
 ## GitHub Issue Routing
 


### PR DESCRIPTION
## Summary

Adds an **RBAC Policy** section to `CLAUDE.md` covering the three documentation items the developer requested in issue #35:

1. **Marker rule**: `// +kubebuilder:rbac` markers must not declare verbs beyond the security-approved baseline in `config/rbac/role.yaml`
2. **Permission-request process**: open a `persona/security` + `type/security` issue first; security updates `role.yaml`; developer then adds the marker
3. **`make manifests` and `role.yaml`**: explains that regeneration is semantically safe when markers are aligned, but formatting differences should not be committed without security persona review; includes the restore command

Also adds `config/rbac/role.yaml` to the Critical Files list with a note that it is security-owned.

## Context

Issue #35 identified that `make manifests` can overwrite the security-crafted `role.yaml`. Option A (developer trims markers to match the approved baseline) was chosen and implemented in PR #40. This PR documents the policy so all personas follow the same rules going forward.

## Test plan

- [ ] `CLAUDE.md` renders correctly in GitHub markdown
- [ ] All three policy points are clear enough that a new persona could follow them without additional context

Related: #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)