### PR TITLE
[test-engineer] errcheck fixes, Ping mock, HTTPClient unit tests (closes #44, #45, #54, #56)

### DIFF
--- a/internal/gea/mock_client_test.go
+++ b/internal/gea/mock_client_test.go
@@ -66,19 +66,23 @@ func TestMockClient_SetErrorNilRestoresDefault(t *testing.T) {
 
 func TestMockClient_AssertPayloadContains(t *testing.T) {
 	m := NewMockClient()
-	m.ReportState(ctx, StatePayload{
+	if err := m.ReportState(ctx, StatePayload{
 		DeviceID: "dev-cluster",
 		Attributes: map[string]interface{}{
 			"health_score": 87,
 			"ready_nodes":  3,
 		},
-	})
-	m.ReportState(ctx, StatePayload{
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ReportState(ctx, StatePayload{
 		DeviceID: "dev-node-1",
 		Attributes: map[string]interface{}{
 			"health_score": 100,
 		},
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Use a recorder to capture any test failures from the helper itself.
 	sub := &testing.T{}
@@ -109,7 +113,9 @@ func TestMockClient_AssertCalled(t *testing.T) {
 		t.Error("AssertCalled: expected failure when no calls recorded")
 	}
 
-	m.ReportState(ctx, StatePayload{DeviceID: "d"})
+	if err := m.ReportState(ctx, StatePayload{DeviceID: "d"}); err != nil {
+		t.Fatal(err)
+	}
 	sub2 := &testing.T{}
 	m.AssertCalled(sub2)
 	if sub2.Failed() {
@@ -126,7 +132,9 @@ func TestMockClient_AssertNotCalled(t *testing.T) {
 		t.Error("AssertNotCalled: expected pass when no calls recorded")
 	}
 
-	m.ReportState(ctx, StatePayload{DeviceID: "d"})
+	if err := m.ReportState(ctx, StatePayload{DeviceID: "d"}); err != nil {
+		t.Fatal(err)
+	}
 	sub2 := &testing.T{}
 	m.AssertNotCalled(sub2)
 	if !sub2.Failed() {
@@ -137,7 +145,7 @@ func TestMockClient_AssertNotCalled(t *testing.T) {
 func TestMockClient_Reset(t *testing.T) {
 	m := NewMockClient()
 	m.SetError(errors.New("err"))
-	m.ReportState(ctx, StatePayload{DeviceID: "d"})
+	_ = m.ReportState(ctx, StatePayload{DeviceID: "d"}) // intentionally discarded: error expected, call count is what matters
 
 	m.Reset()
 	if m.CallCount() != 0 {
@@ -155,7 +163,7 @@ func TestMockClient_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			m.ReportState(ctx, StatePayload{DeviceID: "d", Attributes: map[string]interface{}{"k": 1}})
+			_ = m.ReportState(ctx, StatePayload{DeviceID: "d", Attributes: map[string]interface{}{"k": 1}})
 		}()
 	}
 	wg.Wait()
@@ -172,8 +180,12 @@ func TestMockClient_CustomHandlerFunc(t *testing.T) {
 		return nil
 	}
 
-	m.ReportState(ctx, StatePayload{DeviceID: "dev-a"})
-	m.ReportState(ctx, StatePayload{DeviceID: "dev-b"})
+	if err := m.ReportState(ctx, StatePayload{DeviceID: "dev-a"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ReportState(ctx, StatePayload{DeviceID: "dev-b"}); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(seen) != 2 || seen[0] != "dev-a" || seen[1] != "dev-b" {
 		t.Errorf("custom handler: got %v, want [dev-a dev-b]", seen)

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -1,0 +1,308 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package losant
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
+)
+
+// redirectTransport rewrites the scheme and host of every outbound request to
+// point at the given test server URL, allowing httptest servers to intercept
+// calls that client.go hardcodes to apiBase.
+type redirectTransport struct {
+	serverURL string
+}
+
+func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	parsed, err := url.Parse(rt.serverURL)
+	if err != nil {
+		return nil, err
+	}
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = parsed.Scheme
+	clone.URL.Host = parsed.Host
+	clone.Host = parsed.Host
+	return http.DefaultTransport.RoundTrip(clone)
+}
+
+// newTestHTTPClient constructs an HTTPClient wired to the given httptest server URL.
+// It bypasses NewHTTPClient (which requires a corev1.Secret) so tests can focus on
+// HTTP behaviour without Kubernetes fixtures.
+func newTestHTTPClient(serverURL string) *HTTPClient {
+	return &HTTPClient{
+		deviceID:     "dev-001",
+		accessKey:    "key-abc",
+		accessSecret: "secret-xyz",
+		httpClient: &http.Client{
+			Transport: &redirectTransport{serverURL: serverURL},
+		},
+	}
+}
+
+// newTestSpec returns a minimal LosantSyncSpec for use in tests.
+func newTestSpec() losantv1alpha1.LosantSyncSpec {
+	return losantv1alpha1.LosantSyncSpec{
+		ApplicationID: "app-123",
+		ClusterName:   "test-cluster",
+		Region:        "us-west-1",
+	}
+}
+
+// writeJSON encodes v as JSON with an implicit 200 status.
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// authOK registers a POST /auth/device handler on mux that returns the given token.
+// It increments the returned counter on each call, allowing caching tests to
+// verify that the token exchange happens exactly once.
+func authOK(mux *http.ServeMux, token string) *int32 {
+	var calls int32
+	mux.HandleFunc("POST /auth/device", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		writeJSON(w, authResponse{Token: token, ApplicationID: "app-123"})
+	})
+	return &calls
+}
+
+// --- Constructor ---
+
+func TestNewHTTPClient_MissingKey(t *testing.T) {
+	cases := []struct {
+		name string
+		data map[string][]byte
+	}{
+		{"missing device-id", map[string][]byte{"access-key": []byte("k"), "access-secret": []byte("s")}},
+		{"missing access-key", map[string][]byte{"device-id": []byte("d"), "access-secret": []byte("s")}},
+		{"missing access-secret", map[string][]byte{"device-id": []byte("d"), "access-key": []byte("k")}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			secret := &corev1.Secret{Data: tc.data}
+			if _, err := NewHTTPClient(secret); err == nil {
+				t.Errorf("NewHTTPClient with %s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// --- Ping ---
+
+func TestPing_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	authOK(mux, "tok-1")
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: unexpected error: %v", err)
+	}
+}
+
+func TestPing_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"invalid credentials"}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).Ping(context.Background()); err == nil {
+		t.Fatal("Ping: expected error on 401, got nil")
+	}
+}
+
+// --- Token caching ---
+
+func TestTokenCaching_AuthCalledOnce(t *testing.T) {
+	mux := http.NewServeMux()
+	authCalls := authOK(mux, "tok-cached")
+	// Catch-all for device list calls — both EnsureClusterDevice calls return the same device.
+	mux.HandleFunc("/applications/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{Items: []Device{{DeviceID: "existing-dev", Name: "k8s-cluster-test-cluster"}}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := newTestHTTPClient(srv.URL)
+	spec := newTestSpec()
+	for i := range 2 {
+		if _, err := c.EnsureClusterDevice(context.Background(), spec); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if got := atomic.LoadInt32(authCalls); got != 1 {
+		t.Errorf("POST /auth/device called %d time(s), want 1 (token must be cached)", got)
+	}
+}
+
+// --- EnsureClusterDevice ---
+
+func TestEnsureClusterDevice_Found(t *testing.T) {
+	mux := http.NewServeMux()
+	authOK(mux, "tok")
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{Items: []Device{{DeviceID: "cluster-dev-id", Name: "k8s-cluster-test-cluster"}}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	id, err := newTestHTTPClient(srv.URL).EnsureClusterDevice(context.Background(), newTestSpec())
+	if err != nil {
+		t.Fatalf("EnsureClusterDevice: %v", err)
+	}
+	if id != "cluster-dev-id" {
+		t.Errorf("deviceID: got %q, want %q", id, "cluster-dev-id")
+	}
+}
+
+func TestEnsureClusterDevice_Created(t *testing.T) {
+	var posted bool
+	mux := http.NewServeMux()
+	authOK(mux, "tok")
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{})
+	})
+	mux.HandleFunc("POST /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		posted = true
+		writeJSON(w, Device{DeviceID: "new-cluster-id", Name: "k8s-cluster-test-cluster"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	id, err := newTestHTTPClient(srv.URL).EnsureClusterDevice(context.Background(), newTestSpec())
+	if err != nil {
+		t.Fatalf("EnsureClusterDevice: %v", err)
+	}
+	if id != "new-cluster-id" {
+		t.Errorf("deviceID: got %q, want %q", id, "new-cluster-id")
+	}
+	if !posted {
+		t.Error("expected POST /applications/app-123/devices to be called")
+	}
+}
+
+// --- EnsureNodeDevice ---
+
+func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
+	var postBody map[string]interface{}
+	mux := http.NewServeMux()
+	authOK(mux, "tok")
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{})
+	})
+	mux.HandleFunc("POST /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&postBody)
+		writeJSON(w, Device{DeviceID: "node-dev-id", Name: "k8s-node-test-cluster-node-1"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	id, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-1")
+	if err != nil {
+		t.Fatalf("EnsureNodeDevice: %v", err)
+	}
+	if id != "node-dev-id" {
+		t.Errorf("deviceID: got %q, want %q", id, "node-dev-id")
+	}
+	tags, _ := postBody["tags"].([]interface{})
+	found := false
+	for _, tag := range tags {
+		m, _ := tag.(map[string]interface{})
+		if m["key"] == "nodeName" && m["value"] == "node-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected nodeName=node-1 in POST tags, got: %v", tags)
+	}
+}
+
+// --- UpdateDeviceTags ---
+
+func TestUpdateDeviceTags_CallsPatch(t *testing.T) {
+	var patchBody map[string]interface{}
+	mux := http.NewServeMux()
+	authOK(mux, "tok")
+	mux.HandleFunc("PATCH /applications/app-123/devices/dev-456", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&patchBody)
+		writeJSON(w, struct{}{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := newTestHTTPClient(srv.URL).UpdateDeviceTags(context.Background(), "app-123", "dev-456", map[string]string{"env": "prod"})
+	if err != nil {
+		t.Fatalf("UpdateDeviceTags: %v", err)
+	}
+	if patchBody == nil {
+		t.Fatal("PATCH handler was not called")
+	}
+}
+
+// --- GetDevice ---
+
+func TestGetDevice_ReturnsDevice(t *testing.T) {
+	mux := http.NewServeMux()
+	authOK(mux, "tok")
+	mux.HandleFunc("GET /applications/app-123/devices/dev-789", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, Device{DeviceID: "dev-789", Name: "my-device"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dev, err := newTestHTTPClient(srv.URL).GetDevice(context.Background(), "app-123", "dev-789")
+	if err != nil {
+		t.Fatalf("GetDevice: %v", err)
+	}
+	if dev.DeviceID != "dev-789" {
+		t.Errorf("DeviceID: got %q, want %q", dev.DeviceID, "dev-789")
+	}
+	if dev.Name != "my-device" {
+		t.Errorf("Name: got %q, want %q", dev.Name, "my-device")
+	}
+}
+
+// --- Error propagation ---
+
+func TestNon2xxError_Propagated(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"internal server error"}`, http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).Ping(context.Background()); err == nil {
+		t.Fatal("expected error on 500 response, got nil")
+	}
+}

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -32,12 +32,14 @@ import (
 type MockClient struct {
 	mu sync.Mutex
 
+	PingFunc                func(ctx context.Context) error
 	EnsureClusterDeviceFunc func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error)
 	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error)
 	UpdateDeviceTagsFunc    func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
 	GetDeviceFunc           func(ctx context.Context, applicationID, deviceID string) (*Device, error)
 
 	// Recorded calls — read after test assertions.
+	PingCalls                []struct{}
 	EnsureClusterDeviceCalls []EnsureClusterDeviceCall
 	EnsureNodeDeviceCalls    []EnsureNodeDeviceCall
 	UpdateDeviceTagsCalls    []UpdateDeviceTagsCall
@@ -81,6 +83,9 @@ func NewMockClient() *MockClient {
 func (m *MockClient) SetError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.PingFunc = func(_ context.Context) error {
+		return err
+	}
 	m.EnsureClusterDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec) (string, error) {
 		return "", err
 	}
@@ -99,7 +104,8 @@ func (m *MockClient) SetError(err error) {
 func (m *MockClient) CallCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return len(m.EnsureClusterDeviceCalls) +
+	return len(m.PingCalls) +
+		len(m.EnsureClusterDeviceCalls) +
 		len(m.EnsureNodeDeviceCalls) +
 		len(m.UpdateDeviceTagsCalls) +
 		len(m.GetDeviceCalls)
@@ -109,14 +115,29 @@ func (m *MockClient) CallCount() int {
 func (m *MockClient) Reset() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.PingFunc = nil
 	m.EnsureClusterDeviceFunc = nil
 	m.EnsureNodeDeviceFunc = nil
 	m.UpdateDeviceTagsFunc = nil
 	m.GetDeviceFunc = nil
+	m.PingCalls = nil
 	m.EnsureClusterDeviceCalls = nil
 	m.EnsureNodeDeviceCalls = nil
 	m.UpdateDeviceTagsCalls = nil
 	m.GetDeviceCalls = nil
+}
+
+// Ping implements LosantClient.
+func (m *MockClient) Ping(ctx context.Context) error {
+	m.mu.Lock()
+	m.PingCalls = append(m.PingCalls, struct{}{})
+	fn := m.PingFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx)
+	}
+	return nil
 }
 
 // EnsureClusterDevice implements LosantClient.

--- a/internal/losant/mock_client_test.go
+++ b/internal/losant/mock_client_test.go
@@ -62,11 +62,21 @@ func TestMockClient_DefaultResponses(t *testing.T) {
 func TestMockClient_CallsRecorded(t *testing.T) {
 	m := NewMockClient()
 
-	m.EnsureClusterDevice(ctx, baseSpec)
-	m.EnsureNodeDevice(ctx, baseSpec, "node-a")
-	m.EnsureNodeDevice(ctx, baseSpec, "node-b")
-	m.UpdateDeviceTags(ctx, "app-123", "dev-1", nil)
-	m.GetDevice(ctx, "app-123", "dev-1")
+	if _, err := m.EnsureClusterDevice(ctx, baseSpec); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-a"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-b"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.UpdateDeviceTags(ctx, "app-123", "dev-1", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.GetDevice(ctx, "app-123", "dev-1"); err != nil {
+		t.Fatal(err)
+	}
 
 	if len(m.EnsureClusterDeviceCalls) != 1 {
 		t.Errorf("EnsureClusterDeviceCalls: got %d, want 1", len(m.EnsureClusterDeviceCalls))
@@ -118,7 +128,9 @@ func TestMockClient_CustomHandlerFunc(t *testing.T) {
 
 func TestMockClient_Reset(t *testing.T) {
 	m := NewMockClient()
-	m.EnsureClusterDevice(ctx, baseSpec)
+	if _, err := m.EnsureClusterDevice(ctx, baseSpec); err != nil {
+		t.Fatal(err)
+	}
 	m.SetError(errors.New("err"))
 	m.Reset()
 
@@ -138,7 +150,7 @@ func TestMockClient_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			m.EnsureNodeDevice(ctx, baseSpec, "node")
+			_, _ = m.EnsureNodeDevice(ctx, baseSpec, "node")
 		}(i)
 	}
 	wg.Wait()

--- a/internal/losant/mock_client_test.go
+++ b/internal/losant/mock_client_test.go
@@ -33,6 +33,25 @@ var baseSpec = losantv1alpha1.LosantSyncSpec{
 	Region:        "us-east",
 }
 
+func TestMockClient_Ping_Default(t *testing.T) {
+	m := NewMockClient()
+	if err := m.Ping(ctx); err != nil {
+		t.Errorf("Ping default: got error %v, want nil", err)
+	}
+	if len(m.PingCalls) != 1 {
+		t.Errorf("PingCalls: got %d, want 1", len(m.PingCalls))
+	}
+}
+
+func TestMockClient_Ping_Error(t *testing.T) {
+	m := NewMockClient()
+	want := errors.New("auth failed")
+	m.PingFunc = func(_ context.Context) error { return want }
+	if err := m.Ping(ctx); !errors.Is(err, want) {
+		t.Errorf("Ping error: got %v, want %v", err, want)
+	}
+}
+
 func TestMockClient_DefaultResponses(t *testing.T) {
 	m := NewMockClient()
 
@@ -97,6 +116,9 @@ func TestMockClient_SetError(t *testing.T) {
 	want := errors.New("api down")
 	m.SetError(want)
 
+	if err := m.Ping(ctx); !errors.Is(err, want) {
+		t.Errorf("Ping: got %v, want %v", err, want)
+	}
 	if _, err := m.EnsureClusterDevice(ctx, baseSpec); !errors.Is(err, want) {
 		t.Errorf("EnsureClusterDevice: got %v, want %v", err, want)
 	}

--- a/internal/monitor/health_score_test.go
+++ b/internal/monitor/health_score_test.go
@@ -41,9 +41,9 @@ func TestHealthStatusFromScore(t *testing.T) {
 
 func TestComputeNodeHealthScore(t *testing.T) {
 	cases := []struct {
-		name  string
-		node  NodeHealth
-		want  int
+		name string
+		node NodeHealth
+		want int
 	}{
 		{"healthy node", NodeHealth{Ready: true}, 100},
 		{"not ready", NodeHealth{Ready: false}, 80},


### PR DESCRIPTION
## Summary

- Fix `errcheck` lint violations in `internal/gea/mock_client_test.go` and `internal/losant/mock_client_test.go` — unblocks lint CI on PR #48 and PR #50 (closes #56, duplicate of #51)
- Add `Ping(ctx)` to `MockClient` in `internal/losant/` to satisfy the updated `LosantClient` interface (closes #44)
- Add `httptest`-based unit tests for `internal/losant/client.go` covering all HTTP methods (closes #45)

## Test plan

- [ ] `go test ./internal/gea/... ./internal/losant/...` passes
- [ ] `go vet ./...` passes
- [ ] `make lint` passes (once golangci-lint toolchain issue is resolved in CI)
- [ ] No changes to non-test `.go` files, `api/**`, `cmd/**`, or `helm/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)