### PR TITLE
fix(security): RBAC drift fix — align role.yaml with controller-gen and add kustomize rename patch

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - role.yaml
+  - role_binding.yaml
+  - service_account.yaml
+  - gea_service_account.yaml
+
+patches:
+  - target:
+      kind: ClusterRole
+      name: manager-role
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: losant-device-controller-role
+      - op: add
+        path: /metadata/labels
+        value:
+          app.kubernetes.io/name: losant-device-controller
+          app.kubernetes.io/component: controller

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,10 +36,12 @@ rules:
     resources: ["secrets"]
     verbs: ["get"]
 
-  # LosantSyncReconciler owns the LosantSync CR and updates its status subresource
+  # LosantSyncReconciler owns the LosantSync CR and updates its status subresource.
+  # list+watch are required by controller-runtime to establish the informer cache;
+  # without them the reconciler never receives events and fails with forbidden at startup.
   - apiGroups: ["losant.io"]
     resources: ["losantsyncs"]
-    verbs: ["get", "update", "patch"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["losant.io"]
     resources: ["losantsyncs/status"]
     verbs: ["get", "update", "patch"]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,52 +1,60 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: losant-device-controller-role
-  labels:
-    app.kubernetes.io/name: losant-device-controller
-    app.kubernetes.io/component: controller
+  name: manager-role
 rules:
-  # HealthWatcherReconciler reads cluster topology to compute health metrics
-  - apiGroups: [""]
-    resources: ["nodes"]
-    verbs: ["get", "list", "watch"]
-
-  # HealthWatcherReconciler counts pod states per node (CrashLoopBackOff, OOMKilled, etc.)
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch"]
-
-  # pvc_collector tracks PVCs not in Bound phase
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-
-  # event_collector counts Warning events in a 1-hour sliding window
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list", "watch"]
-
-  # coredns_collector checks CoreDNS Deployment available replicas
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch"]
-
-  # LosantSyncReconciler reads Losant API credentials for device provisioning
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]
-
-  # LosantSyncReconciler owns the LosantSync CR and updates its status subresource.
-  # list+watch are required by controller-runtime to establish the informer cache;
-  # without them the reconciler never receives events and fails with forbidden at startup.
-  - apiGroups: ["losant.io"]
-    resources: ["losantsyncs"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: ["losant.io"]
-    resources: ["losantsyncs/status"]
-    verbs: ["get", "update", "patch"]
-
-  # controller-runtime leader election requires lease management
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - nodes
+  - persistentvolumeclaims
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - losant.io
+  resources:
+  - losantsyncs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - losant.io
+  resources:
+  - losantsyncs/status
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
## Summary

- Adds `list` and `watch` verbs to the `losantsyncs` ClusterRole rule (required by controller-runtime informer cache at startup)
- Replaces hand-crafted `config/rbac/role.yaml` with the exact output of `make manifests` (controller-gen format, `name: manager-role`) so the manifest-drift CI job passes
- Adds `config/rbac/kustomization.yaml` with a JSON 6902 patch that renames `manager-role` → `losant-device-controller-role` and applies `app.kubernetes.io` labels at deploy time

Closes #52. Closes #55. Unblocks #50.

## Test plan

- [ ] Verify `diff <(make manifests --dry-run 2>/dev/null) config/rbac/role.yaml` shows zero diff (manifest-drift CI job passes)
- [ ] Verify `kubectl kustomize config/rbac/` renders `ClusterRole` with `name: losant-device-controller-role` and expected labels
- [ ] Verify `ClusterRoleBinding` still references `losant-device-controller-role` correctly
- [ ] Confirm CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)