### PR TITLE
feat(gitops-manager): split e2e out of make test, add make e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,13 @@ vet: ## Run go vet
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run unit and integration tests with race detector
+test: manifests generate fmt vet envtest ## Run unit and integration tests (no cluster required; excludes test/e2e)
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" \
-	  go test -race ./... -coverprofile cover.out
+	  go test -race $$(go list ./... | grep -v '/test/e2e') -coverprofile cover.out
+
+.PHONY: e2e
+e2e: ## Run e2e tests against a live cluster (KUBECONFIG must be set)
+	go test -race -v -count=1 ./test/e2e/...
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint


### PR DESCRIPTION
## Summary

- `make test` now excludes `test/e2e/` by filtering `go list ./...` output — no cluster required, safe to run in CI
- New `make e2e` target runs `test/e2e/...` with `-v -count=1` — requires `KUBECONFIG` to be set
- No changes to `test/e2e/` source files (those remain qa persona's responsibility)

## Why

`go test ./...` in the old `make test` pulled in `test/e2e` which calls `BeforeSuite` and immediately crashes on CI runners with no kubeconfig (`failed to load kubeconfig — is KUBECONFIG set?`). This blocked PR #48 (qa e2e suite) from passing the Test job.

Tracked in issue #53.

## Test plan
- [ ] `make test` passes on a machine with no `KUBECONFIG` set (CI runners, developer laptops)
- [ ] `make e2e` runs only `test/e2e/...` (confirm with `-v` output)
- [ ] PR #48 (`persona/qa`) can rebase onto this and pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)