### PR TITLE
[qa] Add PDescribe stubs for all pending AC items; update coverage table

### DIFF
--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -201,22 +201,22 @@ Look for lines containing:
 | AC-P-02 | lifecycle_test.go | "enters Suspended immediately when Suspend=true on creation" | Implemented |
 | AC-P-03 | lifecycle_test.go | "transitions from Provisioning to Suspended when Suspend is enabled" | Implemented |
 | AC-P-04 | lifecycle_test.go | "does not remain in the empty phase indefinitely" | Implemented |
-| AC-P-05 | lifecycle_test.go | "transitions from Provisioning to Active after successful GEA report" | Pending #41 #11 #12 |
-| AC-P-06 | lifecycle_test.go | "transitions to Degraded when the GEA is unreachable" | Pending #41 #11 #12 |
-| AC-C-01..08 | lifecycle_test.go | Conditions (GEAReachable, DevicesProvisioned, LastSyncSucceeded) | Pending #41 #11 #12 |
-| AC-S-01..03 | lifecycle_test.go | LastSyncTime, nodeDevices | Pending #41 #11 #12 |
-| AC-GEA-01..06 | lifecycle_test.go | GEA failure/recovery | Pending #41 #11 #12 |
-| AC-REST-01..05 | lifecycle_test.go | REST API failure/recovery | Pending #41 #11 #12 |
-| AC-NODE-ADD-01..04 | (to be added) | New node join | Pending #41 |
-| AC-NODE-RM-01..03 | (to be added) | Node removal | Pending #41 |
-| AC-NODE-CORDON-01..02 | (to be added) | Node cordon | Pending #41 |
+| AC-P-05 | lifecycle_test.go | "transitions from Provisioning to Active after successful GEA report" | Pending #63 |
+| AC-P-06 | lifecycle_test.go | "transitions to Degraded when the GEA is unreachable" | Pending #63 |
+| AC-C-01..08 | lifecycle_test.go | Conditions (GEAReachable, DevicesProvisioned, LastSyncSucceeded) | Pending #63 |
+| AC-S-01..03 | lifecycle_test.go | LastSyncTime, nodeDevices | Pending #63 |
+| AC-GEA-01..06 | lifecycle_test.go | GEA failure/recovery | Pending #63 |
+| AC-REST-01..05 | lifecycle_test.go | REST API failure/recovery | Pending #63 |
+| AC-NODE-ADD-01..04 | lifecycle_test.go | New node join | Pending #63 |
+| AC-NODE-RM-01..03 | lifecycle_test.go | Node removal | Pending #63 |
+| AC-NODE-CORDON-01..02 | lifecycle_test.go | Node cordon | Pending #63 |
 | AC-SCHED-01 | scheduling_test.go | "is set close to the time of creation" | Implemented |
-| AC-SCHED-02..04 | scheduling_test.go | "advances NextScheduledTime by the configured interval after each sync" | Pending #41 |
-| AC-SCHED-05..07 | scheduling_test.go | Cron scheduling behavior | Pending #41 |
-| AC-SCHED-08..10 | scheduling_test.go | Controller restart mid-schedule | Pending #41 |
+| AC-SCHED-02..04 | scheduling_test.go | "advances NextScheduledTime by the configured interval after each sync" | Pending #63 |
+| AC-SCHED-05..07 | scheduling_test.go | Cron scheduling behavior | Pending #63 |
+| AC-SCHED-08..10 | scheduling_test.go | Controller restart mid-schedule | Pending #63 |
 | AC-SUSP-01 | lifecycle_test.go | Phase transitions with suspend | Implemented |
 | AC-SUSP-02 | scheduling_test.go | "stops advancing NextScheduledTime after Suspend is set" | Implemented |
-| AC-SUSP-03 | (to be added) | No HTTP calls while suspended | Pending #41 #11 #12 |
-| AC-SUSP-04 | (to be added) | Resume from suspension → Provisioning | Pending developer TODO |
+| AC-SUSP-03 | lifecycle_test.go | No HTTP calls while suspended | Pending #63 |
+| AC-SUSP-04 | lifecycle_test.go | Resume from suspension → Provisioning | Pending #63 |
 | AC-SUSP-05 | lifecycle_test.go | "phase remains Suspended when reconciled repeatedly" | Implemented |
 | CRD validation | validation_test.go | CEL rules, required fields, port range, defaults | Implemented |

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -169,12 +169,67 @@ var _ = Describe("LosantSync lifecycle", func() {
 
 	// These tests will be enabled once the developer implements provisioning
 	// and GEA reporting (see TODO in internal/controller/losantsync_controller.go).
-	PDescribe("post-provisioning phases [pending: developer TODO]", func() {
+	// Blocked on: #63 (LosantSyncReconciler full reconcile logic).
+	PDescribe("post-provisioning phases [pending: #63]", func() {
 		It("transitions from Provisioning to Active after successful GEA report")
 		It("transitions to Degraded when the GEA is unreachable")
 		It("sets the GEAReachable condition to True when GEA responds")
 		It("sets the DevicesProvisioned condition after all nodes are provisioned")
 		It("populates NodeDevices map with a device ID per k8s node")
 		It("updates LastSyncTime after each successful report")
+
+		// AC-C-01..08 — condition assertions
+		It("GEAReachable=True after a successful metric report to GEA")
+		It("GEAReachable=False with non-empty reason when GEA is unreachable")
+		It("GEAReachable transitions back to True after GEA recovery")
+		It("DevicesProvisioned=True after all nodes have Losant device IDs")
+		It("LastSyncSucceeded=True after each successful GEA report")
+		It("LastSyncSucceeded=False when GEA returns non-2xx response")
+
+		// AC-S-01..03 — sync verification
+		It("lastSyncTime is updated after every successful sync cycle")
+		It("lastSyncTime is not updated when the GEA HTTP call fails")
+		It("nodeDevices contains exactly one entry per ready k8s node")
+
+		// AC-GEA-01..06 — GEA unreachability
+		It("controller does not crash when GEA is unreachable — requeueing with backoff")
+		It("phase transitions to Degraded when GEA is unreachable for a full sync cycle")
+		It("GEAReachable=False reason describes the failure")
+		It("lastSyncTime is not updated during a failed GEA call")
+		It("phase returns to Active and GEAReachable=True after GEA recovers")
+		It("retry interval uses exponential backoff capped at 5 minutes")
+
+		// AC-REST-01..05 — REST API unreachability
+		It("controller does not crash when Losant REST API is unreachable — requeueing with backoff")
+		It("phase remains Provisioning when REST API is unreachable")
+		It("DevicesProvisioned=False with descriptive reason when REST API is unavailable")
+		It("provisioning resumes automatically within one reconcile cycle after REST recovers")
+		It("partial provisioning state persists: previously provisioned nodes are not re-provisioned")
+	})
+
+	// AC-SUSP-03/04 — suspension HTTP and resume behaviour
+	// Blocked on: #63 (LosantSyncReconciler full reconcile logic).
+	PDescribe("suspension HTTP and resume [pending: #63]", func() {
+		It("makes no HTTP calls to GEA or Losant REST API while suspended")
+		It("resuming from suspension (suspend=false) restarts lifecycle from Provisioning")
+	})
+
+	// AC-NODE-ADD-01..04 — new node joins cluster
+	// Blocked on: #63 (LosantSyncReconciler full reconcile logic).
+	PDescribe("new node joins the cluster [pending: #63]", func() {
+		It("attempts to provision a Losant device within one reconcile cycle of a new node appearing")
+		It("status.nodeDevices contains an entry for the new node within 60s of it becoming Ready")
+		It("DevicesProvisioned transitions False→True after the new node is provisioned")
+		It("metrics for the new node appear in the next GEA report after provisioning")
+	})
+
+	// AC-NODE-RM-01..03 / AC-NODE-CORDON-01..02 — node removal and cordoning
+	// Blocked on: #63 (LosantSyncReconciler full reconcile logic).
+	PDescribe("node removal and cordoning [pending: #63]", func() {
+		It("removing a node from the cluster does not cause an error or Degraded phase")
+		It("removed node's entry may remain in nodeDevices and does not re-trigger provisioning")
+		It("removed node does not appear in subsequent GEA metric reports")
+		It("a cordoned node is still included in health metric reports")
+		It("cordoned node health snapshot reflects actual condition (Ready=True even if unschedulable)")
 	})
 })

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -122,8 +122,8 @@ var _ = Describe("LosantSync scheduling", func() {
 	})
 
 	// These scheduling tests require the developer to implement the NextScheduledTime
-	// advance logic after each successful sync cycle.
-	PDescribe("post-sync schedule advance [pending: developer TODO]", func() {
+	// advance logic after each successful sync cycle. Blocked on: #63.
+	PDescribe("post-sync schedule advance [pending: #63]", func() {
 		It("advances NextScheduledTime by the configured interval after each sync")
 		It("advances NextScheduledTime to the next cron tick after each sync")
 		It("persists NextScheduledTime across controller restarts so no cycle is missed")


### PR DESCRIPTION
## Summary

- All previously blocking issues (#39, #41, #11, #12) are now closed; sole remaining blocker is #63
- Adds `PDescribe` stubs in `test/e2e/lifecycle_test.go` for all outstanding acceptance criteria: AC-C (conditions), AC-S (sync verification), AC-GEA (GEA failure/recovery), AC-REST (REST API failure/recovery), AC-NODE-ADD/RM/CORDON, AC-SUSP-03/04
- Updates `PDescribe` labels in both test files to reference `#63` instead of the resolved issues
- Updates `docs/acceptance-criteria.md` coverage table: all pending rows now point to `#63`; "(to be added)" entries are replaced with concrete file references

**Blocked on:** #63 — PDescribe stubs will be converted to active `Describe` blocks once that PR lands.

## Test plan

- [ ] `go vet ./test/e2e/...` passes (no compilation errors)
- [ ] No `PDescribe` blocks reference closed issues (#39, #41, #11, #12)
- [ ] All unstubbed tests (`Describe` blocks) continue to pass against the existing reconciler stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)