### PR TITLE
[docs] Docs updates for PRs #42, #50, #59, #60, #67, #73, #76

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ To manually trigger a docs pass: use the `/docs-refresh` Claude Code skill.
 ```bash
 make generate      # Generate DeepCopy methods from api/ types
 make manifests     # Generate CRD, RBAC, webhook manifests
-make test          # Run all unit + integration tests
+make test          # Run unit + integration tests (excludes test/e2e/ — no cluster required)
+make e2e           # Run end-to-end tests only (requires KUBECONFIG to be set)
 make lint          # Run golangci-lint
 make run           # Run controller locally against ~/.kube/config
 make build         # Build controller binary to bin/
@@ -106,9 +107,11 @@ The developer adds `// +kubebuilder:rbac` markers in Go files so that `make mani
 
 ### `make manifests` and `role.yaml`
 
-`make manifests` (and `make test`, which calls it) will regenerate `config/rbac/role.yaml` from the current markers. If the markers are correctly aligned with the security-approved baseline, the regenerated content is semantically identical to the committed file — but controller-gen may produce different YAML formatting (inline vs. block style). Do not commit the regenerated file without security persona review; restore it with `git checkout config/rbac/role.yaml` if `git diff` shows only formatting changes.
+`make manifests` (and `make test`, which calls it) will regenerate `config/rbac/role.yaml` from the current markers. The committed `role.yaml` is in controller-gen format with `name: manager-role`; a kustomize JSON 6902 patch in `config/rbac/kustomization.yaml` renames it to `losant-device-controller-role` and adds `app.kubernetes.io` labels at deploy time. Do not edit the `name:` field in `role.yaml` directly.
 
-CI does not automatically guard against drift in `role.yaml`. Treat any unexpected `git diff` on that file after running `make manifests` as a signal to check with the security persona.
+**CI actively guards against drift.** The `manifest-drift` CI job (`.github/workflows/ci.yml`) runs `make manifests` then `git diff --exit-code config/rbac/role.yaml` on every push and PR to `develop` and `main`. If the job fails, it means your markers introduced permissions not present in the committed baseline — open a `persona/security` + `type/security` issue before merging.
+
+If `git diff` shows changes to `role.yaml` after a local `make manifests` run, restore it with `git checkout config/rbac/role.yaml` and check with the security persona before proceeding.
 
 ## Critical Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The merge manager is a gatekeeper, not a coder. When reviewing a PR it:
 
 When conflicts exist between two branches, the merge manager creates an issue assigned to both responsible personas and waits for them to resolve it.
 
-For releases: when `develop` is stable, the merge manager creates a PR from `develop` to `main`, bumps `internal/version/version.go`, and tags the release. No other file changes.
+For releases: when `develop` is stable, the merge manager creates a PR from `develop` to `main`, bumps `internal/version/version.go`, and tags the release with a `v*` tag. No other file changes. Pushing the tag triggers `.github/workflows/release.yml`, which runs `make test`, builds and pushes a multi-arch image to `ghcr.io/mak3r/losant-device:<tag>`, and creates a GitHub Release.
 
 ## Product Designer Rules
 
@@ -93,6 +93,7 @@ make run           # Run controller locally against ~/.kube/config
 make build         # Build controller binary to bin/
 make docker-build  # Build container image (set IMG=)
 make docker-push   # Push container image (set IMG=)
+make docker-buildx # Build and push multi-arch image via buildx (set IMG=; optionally PLATFORMS=linux/arm64,linux/amd64)
 make deploy        # Deploy to cluster via kustomize (set IMG=)
 make undeploy      # Remove from cluster
 make install       # Install CRDs only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 | **gitops-manager** | `persona/gitops-manager` | `helm/**`, `config/**` (except `config/rbac/` which is security), `.github/workflows/**`, `Makefile` |
 | **docs** | `persona/docs` | `docs/**`, `README.md`, `CLAUDE.md`, inline `// +kubebuilder:` marker comments |
 | **merge-manager** | — (no commits) | Creates GitHub issues and PR comments only |
+| **product-designer** | `persona/product-designer` | `.claude/plans/**`, GitHub Issues (create only), `docs/architecture.md` (joint with docs) |
 
 ### Hard Rules
 
@@ -30,6 +31,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 - **gitops-manager** never modifies `internal/**` or `api/**`
 - **docs** never modifies `*.go` files or `helm/templates/**`
 - **merge-manager** never commits code of any kind
+- **product-designer** never modifies source files of any kind; creates plans and GitHub issues only
 
 ## Merge Manager Rules
 
@@ -43,6 +45,20 @@ The merge manager is a gatekeeper, not a coder. When reviewing a PR it:
 When conflicts exist between two branches, the merge manager creates an issue assigned to both responsible personas and waits for them to resolve it.
 
 For releases: when `develop` is stable, the merge manager creates a PR from `develop` to `main`, bumps `internal/version/version.go`, and tags the release. No other file changes.
+
+## Product Designer Rules
+
+The product designer is a trusted advisor and orchestrator, not an implementer. When invoked it:
+
+1. Designs system architecture and documents decisions in `.claude/plans/`
+2. Breaks work into GitHub issues with correct `persona/<name>`, `phase/<n>`, and `type/<task|bug|security>` labels
+3. Identifies dependencies between issues and personas; sets blocking relationships explicitly
+4. Advises on trade-offs and scope — proposes changes but never unilaterally implements them
+5. Reviews open issues and PRs to check alignment with architectural intent
+6. Never touches source files, test files, Helm charts, CI workflows, or RBAC manifests
+7. Never merges PRs — gates and merges are the merge manager's responsibility
+
+To invoke: ask Claude to "act as product-designer" or check out `persona/product-designer`.
 
 ## Test Engineer Pairing Model
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ kubectl create secret generic losant-gea-credentials \
   -n losant-system
 
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=losant-access-key=<key> \
-  --from-literal=losant-access-secret=<secret> \
+  --from-literal=device-id=<edge-compute-device-id> \
+  --from-literal=access-key=<key> \
+  --from-literal=access-secret=<secret> \
   -n losant-system
 
 # Deploy operator + GEA
@@ -107,7 +108,8 @@ helm install losant-device helm/ \
 make generate      # regenerate DeepCopy methods
 make manifests     # regenerate CRD/RBAC manifests
 make build         # build controller binary to bin/manager
-make test          # run unit + integration tests
+make test          # run unit + integration tests (no cluster required)
+make e2e           # run end-to-end tests (requires KUBECONFIG)
 make lint          # golangci-lint
 make run           # run controller locally against ~/.kube/config
 make docker-build  # build container image (set IMG=<image>:<tag>)
@@ -123,6 +125,8 @@ See [CLAUDE.md](CLAUDE.md) for agent development instructions and persona workfl
 - [Helm Values](helm/README.md) — full reference for all Helm chart values
 - [Agent Workflow](docs/agent-workflow.md) — multi-agent branch strategy and persona rules
 - [Losant Setup](docs/losant-setup.md) — one-time Losant Application and Edge Compute device configuration
+- [Runbook](docs/runbook.md) — operational procedures: deploy, diagnose, schedule changes, e2e suite
+- [Acceptance Criteria](docs/acceptance-criteria.md) — testable criteria for the full LosantSync reconciliation lifecycle
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ make lint          # golangci-lint
 make run           # run controller locally against ~/.kube/config
 make docker-build  # build container image (set IMG=<image>:<tag>)
 make docker-push   # push container image (set IMG=<image>:<tag>)
+make docker-buildx # build and push multi-arch image via buildx (set IMG=; optionally PLATFORMS=)
 ```
 
 See [CLAUDE.md](CLAUDE.md) for agent development instructions and persona workflow rules.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,24 +152,28 @@ status:
 - Fast path: processes events as they arrive, keeps HealthStore current
 
 **LosantSyncReconciler** runs on schedule:
-- Reads `LosantSync` CR for configuration
-- Calls provisioner to ensure all Losant devices exist
+- Reads `LosantSync` CR and `ProvisioningSecretRef` Secret
 - Checks `Status.NextScheduledTime` — if not yet due, returns `RequeueAfter`
-- When due: reads HealthStore snapshot → builds GEA payload → POSTs to GEA HTTP endpoint
-- Updates `Status.LastSyncTime`, `Status.NextScheduledTime`
+- When due: runs the full reconcile sequence (see below)
+- Updates `Status.LastSyncTime`, `Status.NextScheduledTime`, phase, and conditions
 - Returns `RequeueAfter(nextTime - now)`
 
 ### Scheduling
 
-Uses `github.com/robfig/cron/v3` to compute the next fire time from either a cron expression or a duration interval. Schedule state is persisted in `Status.NextScheduledTime`, so controller restarts re-arm without missing a cycle.
+Uses `github.com/robfig/cron/v3` to compute the next fire time from either `spec.cronSchedule` (cron expression) or `spec.interval` (duration string). Schedule state is persisted in `Status.NextScheduledTime`, so controller restarts re-arm without missing a cycle.
 
-### Provisioner
+### Reconcile Sequence
 
-On each reconcile, before reporting, the provisioner:
-1. Checks `Status.ClusterDeviceID` — creates the Edge Compute device if missing
-2. Lists current k8s nodes — creates peripheral devices for any node not in `Status.NodeDevices`
-3. Updates `health_status` tag on devices if the computed value changed
-4. For removed nodes: stops reporting (soft approach — device remains in Losant for historical data)
+On each scheduled reconcile, `LosantSyncReconciler` executes in order:
+
+1. **Ping** (`lc.Ping`) — verifies provisioning credentials via `POST /auth/device`; sets `phase=Degraded` on failure
+2. **EnsureClusterDevice** (`lc.EnsureClusterDevice`) — creates or retrieves the Edge Compute device; stores device ID in `Status.ClusterDeviceID`; sets `phase=Degraded` on failure
+3. **EnsureNodeDevice** per node in HealthStore (`lc.EnsureNodeDevice`) — creates or retrieves peripheral devices; sets `phase=Degraded` on first failure
+4. **ReportState cluster** (`gc.ReportState`) — POSTs cluster-level metrics to GEA HTTP endpoint; sets `phase=Degraded` on failure
+5. **ReportState per node** (`gc.ReportState`) — best-effort: failures are logged but do not set `Degraded` or block the reconcile
+6. Compute next `NextScheduledTime`; set `DevicesProvisioned=True`, `GEAReachable=True`, `LastSyncSucceeded=True`, `phase=Active`
+
+For removed nodes: the controller stops reporting (device remains in Losant for historical data).
 
 ## Health Score Algorithm
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,12 +38,13 @@ kubectl create secret generic losant-gea-credentials \
 
 ### Provisioning credentials
 
-The controller uses these for Losant REST API calls (device provisioning only):
+The controller reads these three keys to authenticate to the Losant REST API via `POST /auth/device`. The `device-id` must be the Losant device ID of the pre-provisioned cluster Edge Compute device (see [Losant setup guide](losant-setup.md#bootstrap-constraint)):
 
 ```bash
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=losant-access-key=<provisioning-key> \
-  --from-literal=losant-access-secret=<provisioning-secret> \
+  --from-literal=device-id=<edge-compute-device-id> \
+  --from-literal=access-key=<provisioning-key> \
+  --from-literal=access-secret=<provisioning-secret> \
   -n losant-system
 ```
 

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -7,6 +7,8 @@ One-time configuration steps required before deploying the operator.
 - A Losant account at [app.losant.com](https://app.losant.com)
 - An existing Losant Application (or follow step 1 to create one)
 
+> **Bootstrap constraint**: The cluster Edge Compute device (Step 2) must exist in Losant **before** the operator starts. The controller reads its Losant device ID from the provisioning Secret at startup (`device-id` key) and uses it to authenticate via `POST /auth/device`. There is no automatic creation of this device — it must be pre-provisioned manually.
+
 ---
 
 ## Step 1: Create a Losant Application
@@ -70,7 +72,7 @@ The GEA runs an Edge Workflow that receives metric payloads from the controller 
 
 ## Step 5: Create the Provisioning Access Key
 
-The controller uses a separate access key for REST API calls (device provisioning only). This key does not need Edge Compute permissions.
+The controller uses a separate access key to authenticate to the Losant REST API. At startup it exchanges `{deviceId, key, secret}` via `POST /auth/device` to obtain a short-lived bearer token (cached for 23 hours). This key must have read/write access to Devices.
 
 1. Application → **Security** → **Access Keys** → **Add Access Key**
 2. Scope: read/write on Devices
@@ -89,11 +91,15 @@ kubectl create secret generic losant-gea-credentials \
   -n losant-system
 
 # Provisioning credentials — used by the controller for REST API calls
+# device-id must match the Edge Compute device created in Step 2
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=losant-access-key=<provisioning-key-from-step-5> \
-  --from-literal=losant-access-secret=<provisioning-secret-from-step-5> \
+  --from-literal=device-id=<edge-compute-device-id-from-step-2> \
+  --from-literal=access-key=<provisioning-key-from-step-5> \
+  --from-literal=access-secret=<provisioning-secret-from-step-5> \
   -n losant-system
 ```
+
+> **Key names matter**: The controller reads `device-id`, `access-key`, and `access-secret` (not `losant-access-key` / `losant-access-secret`). Using the wrong key names will cause the operator to fail at startup with a missing-key error.
 
 ---
 


### PR DESCRIPTION
## Summary

Accumulated docs updates from the docs agent loop covering all merged PRs since the last docs PR (#47).

- **PR #42** (Losant auth fix): Update `losant-setup.md` — bootstrap constraint callout, correct provisioning secret key names (`device-id`, `access-key`, `access-secret`), document `POST /auth/device` token exchange
- **PRs #50, #59, #60**: Update `CLAUDE.md` — add `make e2e`, document manifest-drift CI enforcement, controller-gen `role.yaml` format and kustomize rename patch; fix provisioning secret keys in `deployment.md`
- **PR #67** (product-designer persona): Add product-designer row, hard rule, and rules section to `CLAUDE.md`; fix README secret keys; add `make e2e`, `make docker-buildx`, runbook and acceptance-criteria links
- **PR #76** (multi-arch/release): Add `make docker-buildx` to `CLAUDE.md` and `README`; document release workflow in Merge Manager Rules
- **PR #73** (LosantSyncReconciler): Replace outdated Provisioner section in `architecture.md` with actual reconcile sequence (Ping → EnsureClusterDevice → EnsureNodeDevice → ReportState cluster → ReportState per-node best-effort); document Degraded/Active phase semantics

## Files changed
- `CLAUDE.md`
- `README.md`
- `docs/losant-setup.md`
- `docs/deployment.md`
- `docs/architecture.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)