### PR TITLE
fix(losant): replace device access key auth with Application API Token (closes #93)

### DIFF
--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -16,12 +16,11 @@ limitations under the License.
 
 // Package losant implements the Losant REST provisioning client.
 //
-// Auth model: Losant requires a device-scoped bearer token obtained by
-// POSTing {"deviceId","key","secret"} to POST /auth/device. The cluster
-// Edge Compute device must be pre-provisioned manually (see docs/losant-setup.md)
-// before the operator starts; its Losant device ID is read from the provisioning
-// Secret under the "device-id" key. Tokens are cached and refreshed automatically
-// 1 hour before their 24-hour expiry window.
+// Auth model: Losant REST API calls require an Application API Token obtained
+// from the Losant dashboard (Application > Security > API Tokens). The token
+// is stored in the provisioning Secret under the "api-token" key and is sent
+// as a Bearer token on every request. No token exchange is needed.
+// Device access keys (MQTT credentials) are not used here.
 package losant
 
 import (
@@ -32,7 +31,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,16 +42,12 @@ const (
 	apiBase         = "https://api.losant.com"
 	deviceClassEdge = "edgeCompute"
 	deviceClassNode = "peripheral"
-	tokenRefreshTTL = 23 * time.Hour // refresh well before Losant's 24-hour token expiry
 )
 
 // LosantClient manages Losant device lifecycle via the REST provisioning API.
-//
-// All methods obtain a short-lived bearer token via POST /auth/device before
-// making any API call. The token is cached and refreshed transparently.
 type LosantClient interface {
-	// Ping verifies that the provisioning credentials are valid by performing
-	// the POST /auth/device token exchange. Returns nil on success.
+	// Ping verifies that the Application API Token is valid by calling GET /me.
+	// Returns nil on success.
 	Ping(ctx context.Context) error
 
 	// EnsureClusterDevice creates or retrieves the Edge Compute device representing this cluster.
@@ -82,60 +76,31 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
-// authResponse is the JSON body returned by POST /auth/device.
-type authResponse struct {
-	Token         string `json:"token"`
-	ApplicationID string `json:"applicationId"`
-}
-
 // HTTPClient implements LosantClient using the Losant REST API.
 type HTTPClient struct {
-	deviceID     string
-	accessKey    string
-	accessSecret string
-
-	mu          sync.RWMutex
-	cachedToken string
-	tokenExpiry time.Time
-
+	token      string
 	httpClient *http.Client
 }
 
 // NewHTTPClient constructs an HTTPClient from a provisioning Secret.
 //
-// The Secret must contain three keys:
-//   - "device-id"      — Losant device ID of the pre-provisioned cluster Edge Compute device
-//   - "access-key"     — Losant application access key
-//   - "access-secret"  — Losant application access secret
-//
-// The cluster device must exist in Losant before the operator starts; see docs/losant-setup.md.
+// The Secret must contain:
+//   - "api-token" — Losant Application API Token (from Application > Security > API Tokens)
 func NewHTTPClient(secret *corev1.Secret) (*HTTPClient, error) {
-	deviceID, ok := secret.Data["device-id"]
+	token, ok := secret.Data["api-token"]
 	if !ok {
-		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"device-id\"",
-			secret.Namespace, secret.Name)
-	}
-	key, ok := secret.Data["access-key"]
-	if !ok {
-		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"access-key\"",
-			secret.Namespace, secret.Name)
-	}
-	sec, ok := secret.Data["access-secret"]
-	if !ok {
-		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"access-secret\"",
+		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"api-token\"",
 			secret.Namespace, secret.Name)
 	}
 	return &HTTPClient{
-		deviceID:     string(deviceID),
-		accessKey:    string(key),
-		accessSecret: string(sec),
-		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		token:      string(token),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 
-// Ping verifies credentials by performing the token exchange.
+// Ping verifies the Application API Token by calling GET /me.
 func (c *HTTPClient) Ping(ctx context.Context) error {
-	_, err := c.bearerToken(ctx)
+	_, err := c.doRequest(ctx, http.MethodGet, apiBase+"/me", nil)
 	return err
 }
 
@@ -198,70 +163,6 @@ func (c *HTTPClient) GetDevice(ctx context.Context, applicationID, deviceID stri
 	return &dev, nil
 }
 
-// bearerToken returns a valid bearer token, refreshing via POST /auth/device when needed.
-func (c *HTTPClient) bearerToken(ctx context.Context) (string, error) {
-	// Fast path: cached token still valid.
-	c.mu.RLock()
-	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
-		t := c.cachedToken
-		c.mu.RUnlock()
-		return t, nil
-	}
-	c.mu.RUnlock()
-
-	// Slow path: exchange credentials for a fresh token.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Double-check under write lock in case another goroutine already refreshed.
-	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
-		return c.cachedToken, nil
-	}
-
-	payload := map[string]string{
-		"deviceId": c.deviceID,
-		"key":      c.accessKey,
-		"secret":   c.accessSecret,
-	}
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("marshal auth payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBase+"/auth/device", bytes.NewReader(b))
-	if err != nil {
-		return "", fmt.Errorf("build auth request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("losant auth: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("read auth response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("losant auth: status %d: %s", resp.StatusCode, respBody)
-	}
-
-	var authResp authResponse
-	if err := json.Unmarshal(respBody, &authResp); err != nil {
-		return "", fmt.Errorf("decode auth response: %w", err)
-	}
-	if authResp.Token == "" {
-		return "", fmt.Errorf("losant auth: empty token in response")
-	}
-
-	c.cachedToken = authResp.Token
-	c.tokenExpiry = time.Now().Add(tokenRefreshTTL)
-	return c.cachedToken, nil
-}
-
 // findDeviceByName returns the first Losant device matching name, or nil if not found.
 func (c *HTTPClient) findDeviceByName(ctx context.Context, applicationID, name string) (*Device, error) {
 	path := fmt.Sprintf("%s/applications/%s/devices?filterField=name&filter=%s",
@@ -312,11 +213,6 @@ func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, clas
 
 // doRequest executes an authenticated HTTP request and returns the response body.
 func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload interface{}) ([]byte, error) {
-	token, err := c.bearerToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("auth: %w", err)
-	}
-
 	var body io.Reader
 	if payload != nil {
 		b, err := json.Marshal(payload)
@@ -330,7 +226,7 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -22,10 +22,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync/atomic"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
 )
@@ -54,9 +54,7 @@ func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error
 // HTTP behaviour without Kubernetes fixtures.
 func newTestHTTPClient(serverURL string) *HTTPClient {
 	return &HTTPClient{
-		deviceID:     "dev-001",
-		accessKey:    "key-abc",
-		accessSecret: "secret-xyz",
+		token: "test-api-token",
 		httpClient: &http.Client{
 			Transport: &redirectTransport{serverURL: serverURL},
 		},
@@ -78,36 +76,29 @@ func writeJSON(w http.ResponseWriter, v interface{}) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-// authOK registers a POST /auth/device handler on mux that returns the given token.
-// It increments the returned counter on each call, allowing caching tests to
-// verify that the token exchange happens exactly once.
-func authOK(mux *http.ServeMux, token string) *int32 {
-	var calls int32
-	mux.HandleFunc("POST /auth/device", func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		writeJSON(w, authResponse{Token: token, ApplicationID: "app-123"})
-	})
-	return &calls
-}
-
 // --- Constructor ---
 
-func TestNewHTTPClient_MissingKey(t *testing.T) {
-	cases := []struct {
-		name string
-		data map[string][]byte
-	}{
-		{"missing device-id", map[string][]byte{"access-key": []byte("k"), "access-secret": []byte("s")}},
-		{"missing access-key", map[string][]byte{"device-id": []byte("d"), "access-secret": []byte("s")}},
-		{"missing access-secret", map[string][]byte{"device-id": []byte("d"), "access-key": []byte("k")}},
+func TestNewHTTPClient_MissingAPIToken(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "losant-creds", Namespace: "default"},
+		Data:       map[string][]byte{"wrong-key": []byte("value")},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			secret := &corev1.Secret{Data: tc.data}
-			if _, err := NewHTTPClient(secret); err == nil {
-				t.Errorf("NewHTTPClient with %s: expected error, got nil", tc.name)
-			}
-		})
+	if _, err := NewHTTPClient(secret); err == nil {
+		t.Error("NewHTTPClient with missing api-token: expected error, got nil")
+	}
+}
+
+func TestNewHTTPClient_Success(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "losant-creds", Namespace: "default"},
+		Data:       map[string][]byte{"api-token": []byte("tok-abc")},
+	}
+	c, err := NewHTTPClient(secret)
+	if err != nil {
+		t.Fatalf("NewHTTPClient: unexpected error: %v", err)
+	}
+	if c.token != "tok-abc" {
+		t.Errorf("token: got %q, want %q", c.token, "tok-abc")
 	}
 }
 
@@ -115,7 +106,9 @@ func TestNewHTTPClient_MissingKey(t *testing.T) {
 
 func TestPing_Success(t *testing.T) {
 	mux := http.NewServeMux()
-	authOK(mux, "tok-1")
+	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]string{"userId": "u-1"})
+	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
@@ -126,7 +119,7 @@ func TestPing_Success(t *testing.T) {
 
 func TestPing_AuthFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message":"invalid credentials"}`, http.StatusUnauthorized)
+		http.Error(w, `{"message":"invalid token"}`, http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
@@ -135,29 +128,21 @@ func TestPing_AuthFailure(t *testing.T) {
 	}
 }
 
-// --- Token caching ---
-
-func TestTokenCaching_AuthCalledOnce(t *testing.T) {
+func TestPing_BearerTokenSent(t *testing.T) {
+	var gotAuth string
 	mux := http.NewServeMux()
-	authCalls := authOK(mux, "tok-cached")
-	// Catch-all for device list calls — both EnsureClusterDevice calls return the same device.
-	mux.HandleFunc("/applications/", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, struct {
-			Items []Device `json:"items"`
-		}{Items: []Device{{DeviceID: "existing-dev", Name: "k8s-cluster-test-cluster"}}})
+	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		writeJSON(w, map[string]string{"userId": "u-1"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	c := newTestHTTPClient(srv.URL)
-	spec := newTestSpec()
-	for i := range 2 {
-		if _, err := c.EnsureClusterDevice(context.Background(), spec); err != nil {
-			t.Fatalf("call %d: %v", i, err)
-		}
+	if err := newTestHTTPClient(srv.URL).Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
 	}
-	if got := atomic.LoadInt32(authCalls); got != 1 {
-		t.Errorf("POST /auth/device called %d time(s), want 1 (token must be cached)", got)
+	if gotAuth != "Bearer test-api-token" {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, "Bearer test-api-token")
 	}
 }
 
@@ -165,7 +150,6 @@ func TestTokenCaching_AuthCalledOnce(t *testing.T) {
 
 func TestEnsureClusterDevice_Found(t *testing.T) {
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
@@ -186,7 +170,6 @@ func TestEnsureClusterDevice_Found(t *testing.T) {
 func TestEnsureClusterDevice_Created(t *testing.T) {
 	var posted bool
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
@@ -216,7 +199,6 @@ func TestEnsureClusterDevice_Created(t *testing.T) {
 func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 	var postBody map[string]interface{}
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
@@ -254,7 +236,6 @@ func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 func TestUpdateDeviceTags_CallsPatch(t *testing.T) {
 	var patchBody map[string]interface{}
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("PATCH /applications/app-123/devices/dev-456", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&patchBody)
 		writeJSON(w, struct{}{})
@@ -275,7 +256,6 @@ func TestUpdateDeviceTags_CallsPatch(t *testing.T) {
 
 func TestGetDevice_ReturnsDevice(t *testing.T) {
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices/dev-789", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, Device{DeviceID: "dev-789", Name: "my-device"})
 	})


### PR DESCRIPTION
## Summary

- Removes the `POST /auth/device` token-exchange flow — device access key tokens are MQTT-only and return 403 on all device provisioning REST calls
- `NewHTTPClient` now reads a single `api-token` key from the provisioning Secret (Losant Application API Token from Application > Security > API Tokens)
- Removes token caching, `sync.RWMutex`, and the three old secret keys (`device-id`, `access-key`, `access-secret`)
- `Ping` now verifies the token via `GET /me` instead of a token exchange

## Test plan

- [ ] Unit tests in `internal/losant/client_test.go` need updating to use the new `token` field — tracked in companion issue for test-engineer
- [ ] `make build` passes (production code builds cleanly)
- [ ] CI Lint and Build jobs green; Test job blocked on test-engineer companion issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)