### PR TITLE
docs: update auth model to Application API Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ kubectl create secret generic losant-gea-credentials \
   -n losant-system
 
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=device-id=<edge-compute-device-id> \
-  --from-literal=access-key=<key> \
-  --from-literal=access-secret=<secret> \
+  --from-literal=api-token=<application-api-token> \
   -n losant-system
 
 # Deploy operator + GEA

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ Uses `github.com/robfig/cron/v3` to compute the next fire time from either `spec
 
 On each scheduled reconcile, `LosantSyncReconciler` executes in order:
 
-1. **Ping** (`lc.Ping`) — verifies provisioning credentials via `POST /auth/device`; sets `phase=Degraded` on failure
+1. **Ping** (`lc.Ping`) — verifies the Application API Token via `GET /me`; sets `phase=Degraded` on failure
 2. **EnsureClusterDevice** (`lc.EnsureClusterDevice`) — creates or retrieves the Edge Compute device; stores device ID in `Status.ClusterDeviceID`; sets `phase=Degraded` on failure
 3. **EnsureNodeDevice** per node in HealthStore (`lc.EnsureNodeDevice`) — creates or retrieves peripheral devices; sets `phase=Degraded` on first failure
 4. **ReportState cluster** (`gc.ReportState`) — POSTs cluster-level metrics to GEA HTTP endpoint; sets `phase=Degraded` on failure

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,13 +38,11 @@ kubectl create secret generic losant-gea-credentials \
 
 ### Provisioning credentials
 
-The controller reads these three keys to authenticate to the Losant REST API via `POST /auth/device`. The `device-id` must be the Losant device ID of the pre-provisioned cluster Edge Compute device (see [Losant setup guide](losant-setup.md#bootstrap-constraint)):
+The controller authenticates to the Losant REST API using a Losant Application API Token (see [Losant setup guide](losant-setup.md#step-5-create-an-application-api-token)). Device access keys cannot be used here — they are MQTT-only credentials.
 
 ```bash
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=device-id=<edge-compute-device-id> \
-  --from-literal=access-key=<provisioning-key> \
-  --from-literal=access-secret=<provisioning-secret> \
+  --from-literal=api-token=<application-api-token> \
   -n losant-system
 ```
 

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -7,7 +7,7 @@ One-time configuration steps required before deploying the operator.
 - A Losant account at [app.losant.com](https://app.losant.com)
 - An existing Losant Application (or follow step 1 to create one)
 
-> **Bootstrap constraint**: The cluster Edge Compute device (Step 2) must exist in Losant **before** the operator starts. The controller reads its Losant device ID from the provisioning Secret at startup (`device-id` key) and uses it to authenticate via `POST /auth/device`. There is no automatic creation of this device — it must be pre-provisioned manually.
+> **Bootstrap constraint**: The cluster Edge Compute device (Step 2) must exist in Losant **before** the operator starts. The controller discovers and manages peripheral (node) devices automatically, but the cluster-level Edge Compute device must be pre-provisioned manually.
 
 ---
 
@@ -70,13 +70,14 @@ The GEA runs an Edge Workflow that receives metric payloads from the controller 
 
 ---
 
-## Step 5: Create the Provisioning Access Key
+## Step 5: Create an Application API Token
 
-The controller uses a separate access key to authenticate to the Losant REST API. At startup it exchanges `{deviceId, key, secret}` via `POST /auth/device` to obtain a short-lived bearer token (cached for 23 hours). This key must have read/write access to Devices.
+The controller authenticates to the Losant REST API using a Losant Application API Token — **not** a device access key. Device access keys are MQTT-only credentials used by the GEA pod; they cannot make REST API calls.
 
-1. Application → **Security** → **Access Keys** → **Add Access Key**
-2. Scope: read/write on Devices
-3. Note the **Access Key** and **Access Secret**
+1. In your Application → **Security** → **API Tokens** → **Add API Token**
+2. Give it a name (e.g., `losant-device-controller`)
+3. Set the expiration as appropriate for your security policy (or leave as no expiration)
+4. Note the **API Token** value (shown only once)
 
 ---
 
@@ -90,16 +91,13 @@ kubectl create secret generic losant-gea-credentials \
   --from-literal=ACCESS_SECRET=<gea-access-secret-from-step-3> \
   -n losant-system
 
-# Provisioning credentials — used by the controller for REST API calls
-# device-id must match the Edge Compute device created in Step 2
+# Provisioning credentials — used by the controller for Losant REST API calls
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=device-id=<edge-compute-device-id-from-step-2> \
-  --from-literal=access-key=<provisioning-key-from-step-5> \
-  --from-literal=access-secret=<provisioning-secret-from-step-5> \
+  --from-literal=api-token=<application-api-token-from-step-5> \
   -n losant-system
 ```
 
-> **Key names matter**: The controller reads `device-id`, `access-key`, and `access-secret` (not `losant-access-key` / `losant-access-secret`). Using the wrong key names will cause the operator to fail at startup with a missing-key error.
+> **Key name matters**: The controller reads a single `api-token` key from this secret. Using any other key name will cause the operator to fail at startup with a missing-key error.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -61,13 +61,11 @@ make install
    kubectl create namespace losant-system
    ```
 
-2. Create the provisioning secret:
+2. Create the provisioning secret (requires a Losant Application API Token — see [docs/losant-setup.md](losant-setup.md#step-5-create-an-application-api-token)):
 
    ```bash
    kubectl create secret generic losant-credentials \
-     --from-literal=device-id=<edge-compute-device-id> \
-     --from-literal=access-key=<key> \
-     --from-literal=access-secret=<secret> \
+     --from-literal=api-token=<application-api-token> \
      -n losant-system
    ```
 
@@ -108,10 +106,9 @@ make install
    ```bash
    kubectl logs -n losant-system deploy/losant-device-controller-manager | grep "provision"
    ```
-2. Verify the provisioning secret exists and contains `device-id`, `access-key`, and `access-secret`:
+2. Verify the provisioning secret exists and contains `api-token`:
    ```bash
-   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.device-id}' | base64 -d
-   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.access-key}' | base64 -d
+   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.api-token}' | base64 -d
    ```
 3. Check `DevicesProvisioned` condition for a reason:
    ```bash


### PR DESCRIPTION
## Summary

- Replaces all references to the old device access key token-exchange flow with Losant Application API Token
- losant-setup.md Step 5 now explains how to create a token from **Application > Security > API Tokens**, with a clear note that device access keys are MQTT-only and cannot be used for REST API calls
- Provisioning secret reduced from 3 keys (`device-id`, `access-key`, `access-secret`) to single `api-token` key
- Deployment.md, runbook.md, architecture.md, and README.md all updated to match

## Related

- Closes #92
- Follows PR #94 (developer fix: replace POST /auth/device with Application API Token)

## Test plan

- [ ] Follow losant-setup.md Steps 5–6 and confirm the described UI path exists in the Losant dashboard
- [ ] Create the provisioning secret with `api-token` key and confirm operator starts without missing-key errors
- [ ] Confirm no remaining references to `device-id`, `access-key`, or `access-secret` in provisioning secret context (GEA secret still uses `DEVICE_ID`/`ACCESS_KEY`/`ACCESS_SECRET` — those are correct and unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)