### PR TITLE
docs: restructure runbook so mode decision routes through all steps

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -8,26 +8,50 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 ## Prerequisites
 
-### Step 1 — Determine your run mode
+### Step 1 — Decide your run mode
 
-All subsequent steps branch on how the controller was started. Decide now:
+All subsequent steps branch on this decision. Pick one now:
 
-- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster
-- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace
+- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing.
+- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging and production.
 
-### Step 2 — Verify CRD is installed (all modes)
+### Step 2 — Install or verify the CRD (all modes)
 
 ```bash
 kubectl get crd losantsyncs.losant.io
 ```
 
-Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found, run `make manifests install`.
+Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found:
 
-### Step 3 — Verify controller is running
+```bash
+make manifests install
+```
+
+### Step 3 — Start the controller
+
+**If you chose `make run`:**
+
+```bash
+make run
+```
+
+The controller starts in your terminal and connects to the cluster in `~/.kube/config`. Keep this terminal open — logs appear here. No namespace or Deployment is created in the cluster.
+
+**If you chose `make deploy`:**
+
+```bash
+# Build and push your image first (set IMG to your registry)
+make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
+
+# Deploy controller + GEA to the losant-system namespace
+make deploy IMG=my-registry/losant-device:v0.x.y
+```
+
+### Step 4 — Verify the controller is running
 
 **If you used `make run`:**
 
-Controller logs appear in the terminal where `make run` is executing. No cluster checks are needed — there is no Deployment or namespace in the cluster.
+Controller logs appear in the terminal from Step 3. No cluster checks are needed.
 
 **If you used `make deploy`:**
 
@@ -38,16 +62,18 @@ kubectl logs -n losant-system deploy/losant-device-controller-manager -f
 
 ---
 
-## Deploying / Upgrading
+## Upgrading an Existing Deployment
+
+These commands apply only when the controller is already running via `make deploy` and you want to update it.
 
 ```bash
-# Build and push image (set IMG to your registry)
+# Build and push the new image
 make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
 
-# Deploy to cluster
+# Roll out the new image
 make deploy IMG=my-registry/losant-device:v0.x.y
 
-# Install / update CRDs only (no controller restart needed for CRD additions)
+# Update CRDs only (no controller restart needed for CRD additions)
 make install
 ```
 
@@ -103,6 +129,10 @@ make install
 ### Phase stuck at Provisioning
 
 1. Check controller logs for provisioning errors:
+
+   **If using `make run`:** look for `provision` in the terminal running the controller.
+
+   **If using `make deploy`:**
    ```bash
    kubectl logs -n losant-system deploy/losant-device-controller-manager | grep "provision"
    ```


### PR DESCRIPTION
## Summary

- Step 1 (decide mode) now routes directly into Step 3 (start the controller), which is branched between `make run` and `make deploy`
- Step 4 (verify controller is running) is presented after the user has actually started it — previously Step 3 asked the user to verify something they hadn't done yet
- The old "Deploying / Upgrading" section is renamed "Upgrading an Existing Deployment" and explicitly scoped to day-2 `make deploy` upgrades, not first-time setup
- `make run` path in Step 3 shows the actual command, not just a description
- "Phase stuck at Provisioning" diagnostic now branches the log-check between `make run` (terminal) and `make deploy` (kubectl)

## Problem

The runbook told users to "decide now" in Step 1 but then presented Step 3 as "Verify controller is running" before telling the user how to start it. The "Deploying / Upgrading" section only covered `make deploy` with no `make run` path — a user choosing `make run` had no guidance on what to actually do.

## Test plan

- [ ] Walk the runbook top-to-bottom choosing `make run` — every step has a clear action or explicit skip instruction
- [ ] Walk the runbook top-to-bottom choosing `make deploy` — every step has a clear action
- [ ] Confirm "Upgrading an Existing Deployment" section is clearly framed as day-2 only

🤖 Generated with [Claude Code](https://claude.com/claude-code)