### PR TITLE
release: merge develop into main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ To manually trigger a docs pass: use the `/docs-refresh` Claude Code skill.
 ```bash
 make generate      # Generate DeepCopy methods from api/ types
 make manifests     # Generate CRD, RBAC, webhook manifests
-make test          # Run all unit + integration tests
+make test          # Run unit + integration tests (excludes test/e2e/ — no cluster required)
+make e2e           # Run end-to-end tests only (requires KUBECONFIG to be set)
 make lint          # Run golangci-lint
 make run           # Run controller locally against ~/.kube/config
 make build         # Build controller binary to bin/
@@ -106,9 +107,11 @@ The developer adds `// +kubebuilder:rbac` markers in Go files so that `make mani
 
 ### `make manifests` and `role.yaml`
 
-`make manifests` (and `make test`, which calls it) will regenerate `config/rbac/role.yaml` from the current markers. If the markers are correctly aligned with the security-approved baseline, the regenerated content is semantically identical to the committed file — but controller-gen may produce different YAML formatting (inline vs. block style). Do not commit the regenerated file without security persona review; restore it with `git checkout config/rbac/role.yaml` if `git diff` shows only formatting changes.
+`make manifests` (and `make test`, which calls it) will regenerate `config/rbac/role.yaml` from the current markers. The committed `role.yaml` is in controller-gen format with `name: manager-role`; a kustomize JSON 6902 patch in `config/rbac/kustomization.yaml` renames it to `losant-device-controller-role` and adds `app.kubernetes.io` labels at deploy time. Do not edit the `name:` field in `role.yaml` directly.
 
-CI does not automatically guard against drift in `role.yaml`. Treat any unexpected `git diff` on that file after running `make manifests` as a signal to check with the security persona.
+**CI actively guards against drift.** The `manifest-drift` CI job (`.github/workflows/ci.yml`) runs `make manifests` then `git diff --exit-code config/rbac/role.yaml` on every push and PR to `develop` and `main`. If the job fails, it means your markers introduced permissions not present in the committed baseline — open a `persona/security` + `type/security` issue before merging.
+
+If `git diff` shows changes to `role.yaml` after a local `make manifests` run, restore it with `git checkout config/rbac/role.yaml` and check with the security persona before proceeding.
 
 ## Critical Files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The merge manager is a gatekeeper, not a coder. When reviewing a PR it:
 
 When conflicts exist between two branches, the merge manager creates an issue assigned to both responsible personas and waits for them to resolve it.
 
-For releases: when `develop` is stable, the merge manager creates a PR from `develop` to `main`, bumps `internal/version/version.go`, and tags the release. No other file changes.
+For releases: when `develop` is stable, the merge manager creates a PR from `develop` to `main`, bumps `internal/version/version.go`, and tags the release with a `v*` tag. No other file changes. Pushing the tag triggers `.github/workflows/release.yml`, which runs `make test`, builds and pushes a multi-arch image to `ghcr.io/mak3r/losant-device:<tag>`, and creates a GitHub Release.
 
 ## Product Designer Rules
 
@@ -93,6 +93,7 @@ make run           # Run controller locally against ~/.kube/config
 make build         # Build controller binary to bin/
 make docker-build  # Build container image (set IMG=)
 make docker-push   # Push container image (set IMG=)
+make docker-buildx # Build and push multi-arch image via buildx (set IMG=; optionally PLATFORMS=linux/arm64,linux/amd64)
 make deploy        # Deploy to cluster via kustomize (set IMG=)
 make undeploy      # Remove from cluster
 make install       # Install CRDs only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 | **gitops-manager** | `persona/gitops-manager` | `helm/**`, `config/**` (except `config/rbac/` which is security), `.github/workflows/**`, `Makefile` |
 | **docs** | `persona/docs` | `docs/**`, `README.md`, `CLAUDE.md`, inline `// +kubebuilder:` marker comments |
 | **merge-manager** | — (no commits) | Creates GitHub issues and PR comments only |
+| **product-designer** | `persona/product-designer` | `.claude/plans/**`, GitHub Issues (create only), `docs/architecture.md` (joint with docs) |
 
 ### Hard Rules
 
@@ -30,6 +31,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 - **gitops-manager** never modifies `internal/**` or `api/**`
 - **docs** never modifies `*.go` files or `helm/templates/**`
 - **merge-manager** never commits code of any kind
+- **product-designer** never modifies source files of any kind; creates plans and GitHub issues only
 
 ## Merge Manager Rules
 
@@ -43,6 +45,20 @@ The merge manager is a gatekeeper, not a coder. When reviewing a PR it:
 When conflicts exist between two branches, the merge manager creates an issue assigned to both responsible personas and waits for them to resolve it.
 
 For releases: when `develop` is stable, the merge manager creates a PR from `develop` to `main`, bumps `internal/version/version.go`, and tags the release. No other file changes.
+
+## Product Designer Rules
+
+The product designer is a trusted advisor and orchestrator, not an implementer. When invoked it:
+
+1. Designs system architecture and documents decisions in `.claude/plans/`
+2. Breaks work into GitHub issues with correct `persona/<name>`, `phase/<n>`, and `type/<task|bug|security>` labels
+3. Identifies dependencies between issues and personas; sets blocking relationships explicitly
+4. Advises on trade-offs and scope — proposes changes but never unilaterally implements them
+5. Reviews open issues and PRs to check alignment with architectural intent
+6. Never touches source files, test files, Helm charts, CI workflows, or RBAC manifests
+7. Never merges PRs — gates and merges are the merge manager's responsibility
+
+To invoke: ask Claude to "act as product-designer" or check out `persona/product-designer`.
 
 ## Test Engineer Pairing Model
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ kubectl create secret generic losant-gea-credentials \
   -n losant-system
 
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=losant-access-key=<key> \
-  --from-literal=losant-access-secret=<secret> \
+  --from-literal=device-id=<edge-compute-device-id> \
+  --from-literal=access-key=<key> \
+  --from-literal=access-secret=<secret> \
   -n losant-system
 
 # Deploy operator + GEA
@@ -107,7 +108,8 @@ helm install losant-device helm/ \
 make generate      # regenerate DeepCopy methods
 make manifests     # regenerate CRD/RBAC manifests
 make build         # build controller binary to bin/manager
-make test          # run unit + integration tests
+make test          # run unit + integration tests (no cluster required)
+make e2e           # run end-to-end tests (requires KUBECONFIG)
 make lint          # golangci-lint
 make run           # run controller locally against ~/.kube/config
 make docker-build  # build container image (set IMG=<image>:<tag>)
@@ -123,6 +125,8 @@ See [CLAUDE.md](CLAUDE.md) for agent development instructions and persona workfl
 - [Helm Values](helm/README.md) — full reference for all Helm chart values
 - [Agent Workflow](docs/agent-workflow.md) — multi-agent branch strategy and persona rules
 - [Losant Setup](docs/losant-setup.md) — one-time Losant Application and Edge Compute device configuration
+- [Runbook](docs/runbook.md) — operational procedures: deploy, diagnose, schedule changes, e2e suite
+- [Acceptance Criteria](docs/acceptance-criteria.md) — testable criteria for the full LosantSync reconciliation lifecycle
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ make lint          # golangci-lint
 make run           # run controller locally against ~/.kube/config
 make docker-build  # build container image (set IMG=<image>:<tag>)
 make docker-push   # push container image (set IMG=<image>:<tag>)
+make docker-buildx # build and push multi-arch image via buildx (set IMG=; optionally PLATFORMS=)
 ```
 
 See [CLAUDE.md](CLAUDE.md) for agent development instructions and persona workflow rules.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ kubectl create secret generic losant-gea-credentials \
   -n losant-system
 
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=device-id=<edge-compute-device-id> \
-  --from-literal=access-key=<key> \
-  --from-literal=access-secret=<secret> \
+  --from-literal=api-token=<application-api-token> \
   -n losant-system
 
 # Deploy operator + GEA

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,24 +152,28 @@ status:
 - Fast path: processes events as they arrive, keeps HealthStore current
 
 **LosantSyncReconciler** runs on schedule:
-- Reads `LosantSync` CR for configuration
-- Calls provisioner to ensure all Losant devices exist
+- Reads `LosantSync` CR and `ProvisioningSecretRef` Secret
 - Checks `Status.NextScheduledTime` — if not yet due, returns `RequeueAfter`
-- When due: reads HealthStore snapshot → builds GEA payload → POSTs to GEA HTTP endpoint
-- Updates `Status.LastSyncTime`, `Status.NextScheduledTime`
+- When due: runs the full reconcile sequence (see below)
+- Updates `Status.LastSyncTime`, `Status.NextScheduledTime`, phase, and conditions
 - Returns `RequeueAfter(nextTime - now)`
 
 ### Scheduling
 
-Uses `github.com/robfig/cron/v3` to compute the next fire time from either a cron expression or a duration interval. Schedule state is persisted in `Status.NextScheduledTime`, so controller restarts re-arm without missing a cycle.
+Uses `github.com/robfig/cron/v3` to compute the next fire time from either `spec.cronSchedule` (cron expression) or `spec.interval` (duration string). Schedule state is persisted in `Status.NextScheduledTime`, so controller restarts re-arm without missing a cycle.
 
-### Provisioner
+### Reconcile Sequence
 
-On each reconcile, before reporting, the provisioner:
-1. Checks `Status.ClusterDeviceID` — creates the Edge Compute device if missing
-2. Lists current k8s nodes — creates peripheral devices for any node not in `Status.NodeDevices`
-3. Updates `health_status` tag on devices if the computed value changed
-4. For removed nodes: stops reporting (soft approach — device remains in Losant for historical data)
+On each scheduled reconcile, `LosantSyncReconciler` executes in order:
+
+1. **Ping** (`lc.Ping`) — verifies provisioning credentials via `POST /auth/device`; sets `phase=Degraded` on failure
+2. **EnsureClusterDevice** (`lc.EnsureClusterDevice`) — creates or retrieves the Edge Compute device; stores device ID in `Status.ClusterDeviceID`; sets `phase=Degraded` on failure
+3. **EnsureNodeDevice** per node in HealthStore (`lc.EnsureNodeDevice`) — creates or retrieves peripheral devices; sets `phase=Degraded` on first failure
+4. **ReportState cluster** (`gc.ReportState`) — POSTs cluster-level metrics to GEA HTTP endpoint; sets `phase=Degraded` on failure
+5. **ReportState per node** (`gc.ReportState`) — best-effort: failures are logged but do not set `Degraded` or block the reconcile
+6. Compute next `NextScheduledTime`; set `DevicesProvisioned=True`, `GEAReachable=True`, `LastSyncSucceeded=True`, `phase=Active`
+
+For removed nodes: the controller stops reporting (device remains in Losant for historical data).
 
 ## Health Score Algorithm
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ Uses `github.com/robfig/cron/v3` to compute the next fire time from either `spec
 
 On each scheduled reconcile, `LosantSyncReconciler` executes in order:
 
-1. **Ping** (`lc.Ping`) — verifies provisioning credentials via `POST /auth/device`; sets `phase=Degraded` on failure
+1. **Ping** (`lc.Ping`) — verifies the Application API Token via `GET /me`; sets `phase=Degraded` on failure
 2. **EnsureClusterDevice** (`lc.EnsureClusterDevice`) — creates or retrieves the Edge Compute device; stores device ID in `Status.ClusterDeviceID`; sets `phase=Degraded` on failure
 3. **EnsureNodeDevice** per node in HealthStore (`lc.EnsureNodeDevice`) — creates or retrieves peripheral devices; sets `phase=Degraded` on first failure
 4. **ReportState cluster** (`gc.ReportState`) — POSTs cluster-level metrics to GEA HTTP endpoint; sets `phase=Degraded` on failure

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,12 +38,13 @@ kubectl create secret generic losant-gea-credentials \
 
 ### Provisioning credentials
 
-The controller uses these for Losant REST API calls (device provisioning only):
+The controller reads these three keys to authenticate to the Losant REST API via `POST /auth/device`. The `device-id` must be the Losant device ID of the pre-provisioned cluster Edge Compute device (see [Losant setup guide](losant-setup.md#bootstrap-constraint)):
 
 ```bash
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=losant-access-key=<provisioning-key> \
-  --from-literal=losant-access-secret=<provisioning-secret> \
+  --from-literal=device-id=<edge-compute-device-id> \
+  --from-literal=access-key=<provisioning-key> \
+  --from-literal=access-secret=<provisioning-secret> \
   -n losant-system
 ```
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,13 +38,11 @@ kubectl create secret generic losant-gea-credentials \
 
 ### Provisioning credentials
 
-The controller reads these three keys to authenticate to the Losant REST API via `POST /auth/device`. The `device-id` must be the Losant device ID of the pre-provisioned cluster Edge Compute device (see [Losant setup guide](losant-setup.md#bootstrap-constraint)):
+The controller authenticates to the Losant REST API using a Losant Application API Token (see [Losant setup guide](losant-setup.md#step-5-create-an-application-api-token)). Device access keys cannot be used here — they are MQTT-only credentials.
 
 ```bash
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=device-id=<edge-compute-device-id> \
-  --from-literal=access-key=<provisioning-key> \
-  --from-literal=access-secret=<provisioning-secret> \
+  --from-literal=api-token=<application-api-token> \
   -n losant-system
 ```
 

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -7,7 +7,7 @@ One-time configuration steps required before deploying the operator.
 - A Losant account at [app.losant.com](https://app.losant.com)
 - An existing Losant Application (or follow step 1 to create one)
 
-> **Bootstrap constraint**: The cluster Edge Compute device (Step 2) must exist in Losant **before** the operator starts. The controller reads its Losant device ID from the provisioning Secret at startup (`device-id` key) and uses it to authenticate via `POST /auth/device`. There is no automatic creation of this device — it must be pre-provisioned manually.
+> **Bootstrap constraint**: The cluster Edge Compute device (Step 2) must exist in Losant **before** the operator starts. The controller discovers and manages peripheral (node) devices automatically, but the cluster-level Edge Compute device must be pre-provisioned manually.
 
 ---
 
@@ -70,13 +70,14 @@ The GEA runs an Edge Workflow that receives metric payloads from the controller 
 
 ---
 
-## Step 5: Create the Provisioning Access Key
+## Step 5: Create an Application API Token
 
-The controller uses a separate access key to authenticate to the Losant REST API. At startup it exchanges `{deviceId, key, secret}` via `POST /auth/device` to obtain a short-lived bearer token (cached for 23 hours). This key must have read/write access to Devices.
+The controller authenticates to the Losant REST API using a Losant Application API Token — **not** a device access key. Device access keys are MQTT-only credentials used by the GEA pod; they cannot make REST API calls.
 
-1. Application → **Security** → **Access Keys** → **Add Access Key**
-2. Scope: read/write on Devices
-3. Note the **Access Key** and **Access Secret**
+1. In your Application → **Security** → **API Tokens** → **Add API Token**
+2. Give it a name (e.g., `losant-device-controller`)
+3. Set the expiration as appropriate for your security policy (or leave as no expiration)
+4. Note the **API Token** value (shown only once)
 
 ---
 
@@ -90,16 +91,13 @@ kubectl create secret generic losant-gea-credentials \
   --from-literal=ACCESS_SECRET=<gea-access-secret-from-step-3> \
   -n losant-system
 
-# Provisioning credentials — used by the controller for REST API calls
-# device-id must match the Edge Compute device created in Step 2
+# Provisioning credentials — used by the controller for Losant REST API calls
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=device-id=<edge-compute-device-id-from-step-2> \
-  --from-literal=access-key=<provisioning-key-from-step-5> \
-  --from-literal=access-secret=<provisioning-secret-from-step-5> \
+  --from-literal=api-token=<application-api-token-from-step-5> \
   -n losant-system
 ```
 
-> **Key names matter**: The controller reads `device-id`, `access-key`, and `access-secret` (not `losant-access-key` / `losant-access-secret`). Using the wrong key names will cause the operator to fail at startup with a missing-key error.
+> **Key name matters**: The controller reads a single `api-token` key from this secret. Using any other key name will cause the operator to fail at startup with a missing-key error.
 
 ---
 

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -7,6 +7,8 @@ One-time configuration steps required before deploying the operator.
 - A Losant account at [app.losant.com](https://app.losant.com)
 - An existing Losant Application (or follow step 1 to create one)
 
+> **Bootstrap constraint**: The cluster Edge Compute device (Step 2) must exist in Losant **before** the operator starts. The controller reads its Losant device ID from the provisioning Secret at startup (`device-id` key) and uses it to authenticate via `POST /auth/device`. There is no automatic creation of this device — it must be pre-provisioned manually.
+
 ---
 
 ## Step 1: Create a Losant Application
@@ -70,7 +72,7 @@ The GEA runs an Edge Workflow that receives metric payloads from the controller 
 
 ## Step 5: Create the Provisioning Access Key
 
-The controller uses a separate access key for REST API calls (device provisioning only). This key does not need Edge Compute permissions.
+The controller uses a separate access key to authenticate to the Losant REST API. At startup it exchanges `{deviceId, key, secret}` via `POST /auth/device` to obtain a short-lived bearer token (cached for 23 hours). This key must have read/write access to Devices.
 
 1. Application → **Security** → **Access Keys** → **Add Access Key**
 2. Scope: read/write on Devices
@@ -89,11 +91,15 @@ kubectl create secret generic losant-gea-credentials \
   -n losant-system
 
 # Provisioning credentials — used by the controller for REST API calls
+# device-id must match the Edge Compute device created in Step 2
 kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=losant-access-key=<provisioning-key-from-step-5> \
-  --from-literal=losant-access-secret=<provisioning-secret-from-step-5> \
+  --from-literal=device-id=<edge-compute-device-id-from-step-2> \
+  --from-literal=access-key=<provisioning-key-from-step-5> \
+  --from-literal=access-secret=<provisioning-secret-from-step-5> \
   -n losant-system
 ```
+
+> **Key names matter**: The controller reads `device-id`, `access-key`, and `access-secret` (not `losant-access-key` / `losant-access-secret`). Using the wrong key names will cause the operator to fail at startup with a missing-key error.
 
 ---
 

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -34,7 +34,7 @@ This device represents the cluster in Losant. Its credentials are used by the GE
    region       = <your-region>
    health_status = provisioning
    ```
-5. Under **Attributes**, add these (data type: `number` for all except `controller_version`):
+5. Under **Attributes**, add these (data type: `number` for all):
    ```
    total_nodes, ready_nodes, unhealthy_nodes
    total_pods, running_pods, failed_pods, pending_pods, crashloop_pods

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -61,13 +61,11 @@ make install
    kubectl create namespace losant-system
    ```
 
-2. Create the provisioning secret:
+2. Create the provisioning secret (requires a Losant Application API Token — see [docs/losant-setup.md](losant-setup.md#step-5-create-an-application-api-token)):
 
    ```bash
    kubectl create secret generic losant-credentials \
-     --from-literal=device-id=<edge-compute-device-id> \
-     --from-literal=access-key=<key> \
-     --from-literal=access-secret=<secret> \
+     --from-literal=api-token=<application-api-token> \
      -n losant-system
    ```
 
@@ -108,10 +106,9 @@ make install
    ```bash
    kubectl logs -n losant-system deploy/losant-device-controller-manager | grep "provision"
    ```
-2. Verify the provisioning secret exists and contains `device-id`, `access-key`, and `access-secret`:
+2. Verify the provisioning secret exists and contains `api-token`:
    ```bash
-   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.device-id}' | base64 -d
-   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.access-key}' | base64 -d
+   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.api-token}' | base64 -d
    ```
 3. Check `DevicesProvisioned` condition for a reason:
    ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -2,31 +2,37 @@
 
 Operational procedures for the `losant-device` Kubernetes controller running on k3s clusters.
 
+> **Before you begin**: Complete the one-time Losant setup in [docs/losant-setup.md](losant-setup.md) first. You will need the Edge Compute device ID, access key, and access secret from that guide before the commands below will work.
+
 ---
 
 ## Prerequisites
 
-Always verify the CRD is installed first:
+### Step 1 — Determine your run mode
+
+All subsequent steps branch on how the controller was started. Decide now:
+
+- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster
+- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace
+
+### Step 2 — Verify CRD is installed (all modes)
 
 ```bash
 kubectl get crd losantsyncs.losant.io
 ```
 
-Then check the controller depending on how it was started:
+Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found, run `make manifests install`.
 
-**Using `make run` (controller runs as a local process):**
-```bash
-# No namespace or deployment is created in the cluster.
-# Controller logs appear in the terminal where make run is executing.
-# The only in-cluster check needed is the CRD above.
-```
+### Step 3 — Verify controller is running
 
-**Using `make deploy` (controller runs as an in-cluster pod):**
+**If you used `make run`:**
+
+Controller logs appear in the terminal where `make run` is executing. No cluster checks are needed — there is no Deployment or namespace in the cluster.
+
+**If you used `make deploy`:**
+
 ```bash
-# Check the controller deployment
 kubectl get deploy -n losant-system losant-device-controller-manager
-
-# Tail controller logs
 kubectl logs -n losant-system deploy/losant-device-controller-manager -f
 ```
 
@@ -49,7 +55,13 @@ make install
 
 ## Creating a LosantSync Resource
 
-1. Create the provisioning secret in the target namespace:
+1. Create the `losant-system` namespace if it does not already exist (skip if you used `make deploy`, which creates it automatically):
+
+   ```bash
+   kubectl create namespace losant-system
+   ```
+
+2. Create the provisioning secret:
 
    ```bash
    kubectl create secret generic losant-credentials \
@@ -59,7 +71,7 @@ make install
      -n losant-system
    ```
 
-2. Apply a `LosantSync` manifest:
+3. Apply a `LosantSync` manifest:
 
    ```yaml
    apiVersion: losant.io/v1alpha1
@@ -79,7 +91,7 @@ make install
        port: 8080
    ```
 
-3. Monitor startup:
+4. Monitor startup:
 
    ```bash
    watch kubectl get losantsync my-cluster

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -6,11 +6,24 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 ## Prerequisites
 
-```bash
-# Verify CRD is installed
-kubectl get crd losantsyncs.losant.io
+Always verify the CRD is installed first:
 
-# Check controller is running
+```bash
+kubectl get crd losantsyncs.losant.io
+```
+
+Then check the controller depending on how it was started:
+
+**Using `make run` (controller runs as a local process):**
+```bash
+# No namespace or deployment is created in the cluster.
+# Controller logs appear in the terminal where make run is executing.
+# The only in-cluster check needed is the CRD above.
+```
+
+**Using `make deploy` (controller runs as an in-cluster pod):**
+```bash
+# Check the controller deployment
 kubectl get deploy -n losant-system losant-device-controller-manager
 
 # Tail controller logs
@@ -40,8 +53,9 @@ make install
 
    ```bash
    kubectl create secret generic losant-credentials \
-     --from-literal=accessKey=<key> \
-     --from-literal=accessSecret=<secret> \
+     --from-literal=device-id=<edge-compute-device-id> \
+     --from-literal=access-key=<key> \
+     --from-literal=access-secret=<secret> \
      -n losant-system
    ```
 
@@ -82,9 +96,10 @@ make install
    ```bash
    kubectl logs -n losant-system deploy/losant-device-controller-manager | grep "provision"
    ```
-2. Verify the provisioning secret exists and contains `accessKey` and `accessSecret`:
+2. Verify the provisioning secret exists and contains `device-id`, `access-key`, and `access-secret`:
    ```bash
-   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data}' | base64 -d
+   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.device-id}' | base64 -d
+   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.access-key}' | base64 -d
    ```
 3. Check `DevicesProvisioned` condition for a reason:
    ```bash
@@ -199,12 +214,13 @@ make run
 # or: make deploy IMG=...
 ```
 
-### Known pending tests
+### Known skipped tests
 
-Several test cases are marked `PDescribe` (pending) because the developer has not yet implemented:
-- Device provisioning via the Losant REST API (blocked on #41, #11, #12)
-- Active/Degraded phase transitions
-- Post-sync `nextScheduledTime` advance
+Several test cases are marked `Skip` because they require live cluster operations not automatable in CI:
+- Node add / node remove (requires adding/removing a real cluster node)
+- Controller restart mid-schedule (requires `kubectl rollout restart` against a live controller pod)
+
+All other criteria are implemented and run automatically.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -8,26 +8,50 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 ## Prerequisites
 
-### Step 1 — Determine your run mode
+### Step 1 — Decide your run mode
 
-All subsequent steps branch on how the controller was started. Decide now:
+All subsequent steps branch on this decision. Pick one now:
 
-- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster
-- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace
+- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing.
+- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging and production.
 
-### Step 2 — Verify CRD is installed (all modes)
+### Step 2 — Install or verify the CRD (all modes)
 
 ```bash
 kubectl get crd losantsyncs.losant.io
 ```
 
-Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found, run `make manifests install`.
+Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found:
 
-### Step 3 — Verify controller is running
+```bash
+make manifests install
+```
+
+### Step 3 — Start the controller
+
+**If you chose `make run`:**
+
+```bash
+make run
+```
+
+The controller starts in your terminal and connects to the cluster in `~/.kube/config`. Keep this terminal open — logs appear here. No namespace or Deployment is created in the cluster.
+
+**If you chose `make deploy`:**
+
+```bash
+# Build and push your image first (set IMG to your registry)
+make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
+
+# Deploy controller + GEA to the losant-system namespace
+make deploy IMG=my-registry/losant-device:v0.x.y
+```
+
+### Step 4 — Verify the controller is running
 
 **If you used `make run`:**
 
-Controller logs appear in the terminal where `make run` is executing. No cluster checks are needed — there is no Deployment or namespace in the cluster.
+Controller logs appear in the terminal from Step 3. No cluster checks are needed.
 
 **If you used `make deploy`:**
 
@@ -38,16 +62,18 @@ kubectl logs -n losant-system deploy/losant-device-controller-manager -f
 
 ---
 
-## Deploying / Upgrading
+## Upgrading an Existing Deployment
+
+These commands apply only when the controller is already running via `make deploy` and you want to update it.
 
 ```bash
-# Build and push image (set IMG to your registry)
+# Build and push the new image
 make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
 
-# Deploy to cluster
+# Roll out the new image
 make deploy IMG=my-registry/losant-device:v0.x.y
 
-# Install / update CRDs only (no controller restart needed for CRD additions)
+# Update CRDs only (no controller restart needed for CRD additions)
 make install
 ```
 
@@ -103,6 +129,10 @@ make install
 ### Phase stuck at Provisioning
 
 1. Check controller logs for provisioning errors:
+
+   **If using `make run`:** look for `provision` in the terminal running the controller.
+
+   **If using `make deploy`:**
    ```bash
    kubectl logs -n losant-system deploy/losant-device-controller-manager | grep "provision"
    ```

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -16,12 +16,11 @@ limitations under the License.
 
 // Package losant implements the Losant REST provisioning client.
 //
-// Auth model: Losant requires a device-scoped bearer token obtained by
-// POSTing {"deviceId","key","secret"} to POST /auth/device. The cluster
-// Edge Compute device must be pre-provisioned manually (see docs/losant-setup.md)
-// before the operator starts; its Losant device ID is read from the provisioning
-// Secret under the "device-id" key. Tokens are cached and refreshed automatically
-// 1 hour before their 24-hour expiry window.
+// Auth model: Losant REST API calls require an Application API Token obtained
+// from the Losant dashboard (Application > Security > API Tokens). The token
+// is stored in the provisioning Secret under the "api-token" key and is sent
+// as a Bearer token on every request. No token exchange is needed.
+// Device access keys (MQTT credentials) are not used here.
 package losant
 
 import (
@@ -32,7 +31,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,16 +42,12 @@ const (
 	apiBase         = "https://api.losant.com"
 	deviceClassEdge = "edgeCompute"
 	deviceClassNode = "peripheral"
-	tokenRefreshTTL = 23 * time.Hour // refresh well before Losant's 24-hour token expiry
 )
 
 // LosantClient manages Losant device lifecycle via the REST provisioning API.
-//
-// All methods obtain a short-lived bearer token via POST /auth/device before
-// making any API call. The token is cached and refreshed transparently.
 type LosantClient interface {
-	// Ping verifies that the provisioning credentials are valid by performing
-	// the POST /auth/device token exchange. Returns nil on success.
+	// Ping verifies that the Application API Token is valid by calling GET /me.
+	// Returns nil on success.
 	Ping(ctx context.Context) error
 
 	// EnsureClusterDevice creates or retrieves the Edge Compute device representing this cluster.
@@ -82,60 +76,31 @@ type Tag struct {
 	Value string `json:"value"`
 }
 
-// authResponse is the JSON body returned by POST /auth/device.
-type authResponse struct {
-	Token         string `json:"token"`
-	ApplicationID string `json:"applicationId"`
-}
-
 // HTTPClient implements LosantClient using the Losant REST API.
 type HTTPClient struct {
-	deviceID     string
-	accessKey    string
-	accessSecret string
-
-	mu          sync.RWMutex
-	cachedToken string
-	tokenExpiry time.Time
-
+	token      string
 	httpClient *http.Client
 }
 
 // NewHTTPClient constructs an HTTPClient from a provisioning Secret.
 //
-// The Secret must contain three keys:
-//   - "device-id"      — Losant device ID of the pre-provisioned cluster Edge Compute device
-//   - "access-key"     — Losant application access key
-//   - "access-secret"  — Losant application access secret
-//
-// The cluster device must exist in Losant before the operator starts; see docs/losant-setup.md.
+// The Secret must contain:
+//   - "api-token" — Losant Application API Token (from Application > Security > API Tokens)
 func NewHTTPClient(secret *corev1.Secret) (*HTTPClient, error) {
-	deviceID, ok := secret.Data["device-id"]
+	token, ok := secret.Data["api-token"]
 	if !ok {
-		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"device-id\"",
-			secret.Namespace, secret.Name)
-	}
-	key, ok := secret.Data["access-key"]
-	if !ok {
-		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"access-key\"",
-			secret.Namespace, secret.Name)
-	}
-	sec, ok := secret.Data["access-secret"]
-	if !ok {
-		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"access-secret\"",
+		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"api-token\"",
 			secret.Namespace, secret.Name)
 	}
 	return &HTTPClient{
-		deviceID:     string(deviceID),
-		accessKey:    string(key),
-		accessSecret: string(sec),
-		httpClient:   &http.Client{Timeout: 30 * time.Second},
+		token:      string(token),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 
-// Ping verifies credentials by performing the token exchange.
+// Ping verifies the Application API Token by calling GET /me.
 func (c *HTTPClient) Ping(ctx context.Context) error {
-	_, err := c.bearerToken(ctx)
+	_, err := c.doRequest(ctx, http.MethodGet, apiBase+"/me", nil)
 	return err
 }
 
@@ -198,70 +163,6 @@ func (c *HTTPClient) GetDevice(ctx context.Context, applicationID, deviceID stri
 	return &dev, nil
 }
 
-// bearerToken returns a valid bearer token, refreshing via POST /auth/device when needed.
-func (c *HTTPClient) bearerToken(ctx context.Context) (string, error) {
-	// Fast path: cached token still valid.
-	c.mu.RLock()
-	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
-		t := c.cachedToken
-		c.mu.RUnlock()
-		return t, nil
-	}
-	c.mu.RUnlock()
-
-	// Slow path: exchange credentials for a fresh token.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Double-check under write lock in case another goroutine already refreshed.
-	if c.cachedToken != "" && time.Now().Before(c.tokenExpiry) {
-		return c.cachedToken, nil
-	}
-
-	payload := map[string]string{
-		"deviceId": c.deviceID,
-		"key":      c.accessKey,
-		"secret":   c.accessSecret,
-	}
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("marshal auth payload: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiBase+"/auth/device", bytes.NewReader(b))
-	if err != nil {
-		return "", fmt.Errorf("build auth request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("losant auth: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("read auth response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("losant auth: status %d: %s", resp.StatusCode, respBody)
-	}
-
-	var authResp authResponse
-	if err := json.Unmarshal(respBody, &authResp); err != nil {
-		return "", fmt.Errorf("decode auth response: %w", err)
-	}
-	if authResp.Token == "" {
-		return "", fmt.Errorf("losant auth: empty token in response")
-	}
-
-	c.cachedToken = authResp.Token
-	c.tokenExpiry = time.Now().Add(tokenRefreshTTL)
-	return c.cachedToken, nil
-}
-
 // findDeviceByName returns the first Losant device matching name, or nil if not found.
 func (c *HTTPClient) findDeviceByName(ctx context.Context, applicationID, name string) (*Device, error) {
 	path := fmt.Sprintf("%s/applications/%s/devices?filterField=name&filter=%s",
@@ -312,11 +213,6 @@ func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, clas
 
 // doRequest executes an authenticated HTTP request and returns the response body.
 func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload interface{}) ([]byte, error) {
-	token, err := c.bearerToken(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("auth: %w", err)
-	}
-
 	var body io.Reader
 	if payload != nil {
 		b, err := json.Marshal(payload)
@@ -330,7 +226,7 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+c.token)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -22,10 +22,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"sync/atomic"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
 )
@@ -54,9 +54,7 @@ func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error
 // HTTP behaviour without Kubernetes fixtures.
 func newTestHTTPClient(serverURL string) *HTTPClient {
 	return &HTTPClient{
-		deviceID:     "dev-001",
-		accessKey:    "key-abc",
-		accessSecret: "secret-xyz",
+		token: "test-api-token",
 		httpClient: &http.Client{
 			Transport: &redirectTransport{serverURL: serverURL},
 		},
@@ -78,36 +76,29 @@ func writeJSON(w http.ResponseWriter, v interface{}) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-// authOK registers a POST /auth/device handler on mux that returns the given token.
-// It increments the returned counter on each call, allowing caching tests to
-// verify that the token exchange happens exactly once.
-func authOK(mux *http.ServeMux, token string) *int32 {
-	var calls int32
-	mux.HandleFunc("POST /auth/device", func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&calls, 1)
-		writeJSON(w, authResponse{Token: token, ApplicationID: "app-123"})
-	})
-	return &calls
-}
-
 // --- Constructor ---
 
-func TestNewHTTPClient_MissingKey(t *testing.T) {
-	cases := []struct {
-		name string
-		data map[string][]byte
-	}{
-		{"missing device-id", map[string][]byte{"access-key": []byte("k"), "access-secret": []byte("s")}},
-		{"missing access-key", map[string][]byte{"device-id": []byte("d"), "access-secret": []byte("s")}},
-		{"missing access-secret", map[string][]byte{"device-id": []byte("d"), "access-key": []byte("k")}},
+func TestNewHTTPClient_MissingAPIToken(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "losant-creds", Namespace: "default"},
+		Data:       map[string][]byte{"wrong-key": []byte("value")},
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			secret := &corev1.Secret{Data: tc.data}
-			if _, err := NewHTTPClient(secret); err == nil {
-				t.Errorf("NewHTTPClient with %s: expected error, got nil", tc.name)
-			}
-		})
+	if _, err := NewHTTPClient(secret); err == nil {
+		t.Error("NewHTTPClient with missing api-token: expected error, got nil")
+	}
+}
+
+func TestNewHTTPClient_Success(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "losant-creds", Namespace: "default"},
+		Data:       map[string][]byte{"api-token": []byte("tok-abc")},
+	}
+	c, err := NewHTTPClient(secret)
+	if err != nil {
+		t.Fatalf("NewHTTPClient: unexpected error: %v", err)
+	}
+	if c.token != "tok-abc" {
+		t.Errorf("token: got %q, want %q", c.token, "tok-abc")
 	}
 }
 
@@ -115,7 +106,9 @@ func TestNewHTTPClient_MissingKey(t *testing.T) {
 
 func TestPing_Success(t *testing.T) {
 	mux := http.NewServeMux()
-	authOK(mux, "tok-1")
+	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]string{"userId": "u-1"})
+	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
@@ -126,7 +119,7 @@ func TestPing_Success(t *testing.T) {
 
 func TestPing_AuthFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, `{"message":"invalid credentials"}`, http.StatusUnauthorized)
+		http.Error(w, `{"message":"invalid token"}`, http.StatusUnauthorized)
 	}))
 	defer srv.Close()
 
@@ -135,29 +128,21 @@ func TestPing_AuthFailure(t *testing.T) {
 	}
 }
 
-// --- Token caching ---
-
-func TestTokenCaching_AuthCalledOnce(t *testing.T) {
+func TestPing_BearerTokenSent(t *testing.T) {
+	var gotAuth string
 	mux := http.NewServeMux()
-	authCalls := authOK(mux, "tok-cached")
-	// Catch-all for device list calls — both EnsureClusterDevice calls return the same device.
-	mux.HandleFunc("/applications/", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, struct {
-			Items []Device `json:"items"`
-		}{Items: []Device{{DeviceID: "existing-dev", Name: "k8s-cluster-test-cluster"}}})
+	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		writeJSON(w, map[string]string{"userId": "u-1"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	c := newTestHTTPClient(srv.URL)
-	spec := newTestSpec()
-	for i := range 2 {
-		if _, err := c.EnsureClusterDevice(context.Background(), spec); err != nil {
-			t.Fatalf("call %d: %v", i, err)
-		}
+	if err := newTestHTTPClient(srv.URL).Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: %v", err)
 	}
-	if got := atomic.LoadInt32(authCalls); got != 1 {
-		t.Errorf("POST /auth/device called %d time(s), want 1 (token must be cached)", got)
+	if gotAuth != "Bearer test-api-token" {
+		t.Errorf("Authorization header: got %q, want %q", gotAuth, "Bearer test-api-token")
 	}
 }
 
@@ -165,7 +150,6 @@ func TestTokenCaching_AuthCalledOnce(t *testing.T) {
 
 func TestEnsureClusterDevice_Found(t *testing.T) {
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
@@ -186,7 +170,6 @@ func TestEnsureClusterDevice_Found(t *testing.T) {
 func TestEnsureClusterDevice_Created(t *testing.T) {
 	var posted bool
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
@@ -216,7 +199,6 @@ func TestEnsureClusterDevice_Created(t *testing.T) {
 func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 	var postBody map[string]interface{}
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
@@ -254,7 +236,6 @@ func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 func TestUpdateDeviceTags_CallsPatch(t *testing.T) {
 	var patchBody map[string]interface{}
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("PATCH /applications/app-123/devices/dev-456", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(r.Body).Decode(&patchBody)
 		writeJSON(w, struct{}{})
@@ -275,7 +256,6 @@ func TestUpdateDeviceTags_CallsPatch(t *testing.T) {
 
 func TestGetDevice_ReturnsDevice(t *testing.T) {
 	mux := http.NewServeMux()
-	authOK(mux, "tok")
 	mux.HandleFunc("GET /applications/app-123/devices/dev-789", func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, Device{DeviceID: "dev-789", Name: "my-device"})
 	})


### PR DESCRIPTION
## Summary

Brings main up to date with develop. Key fixes included:

- **Auth model corrected**: provisioning secret now uses single `api-token` key (Losant Application API Token); removes incorrect device access key flow that returned 403 on all REST calls
- **losant-setup.md Step 2 #5**: removed phantom `controller_version` attribute; all cluster device attributes are `number` type
- **Runbook restructured**: mode decision (make run vs make deploy) now routes through all steps; Step 3 starts the controller, Step 4 verifies it
- **Namespace creation**: added explicit `kubectl create namespace losant-system` step for the `make run` path
- **Secret key names corrected**: `device-id`, `access-key`, `access-secret` fixed throughout; now replaced by `api-token`
- **Full LosantSyncReconciler implementation** and supporting unit/integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)