### PR TITLE
feat(security): add govulncheck and RBAC drift detection to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,20 @@ jobs:
                   print(f"  apiGroup={g!r} resource={res!r} verb={v!r}")
           sys.exit(1)
           EOF
+
+  govulncheck:
+    name: Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check for Go vulnerabilities
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...


### PR DESCRIPTION
## Summary

Adds a `govulncheck` (Vulnerability Scan) job to \`.github/workflows/ci.yml\` that scans all Go packages for known CVEs on every PR and push to \`develop\`/\`main\`.

This is the security persona's addition. RBAC drift detection (\`manifest-drift\` job) was already present on \`develop\` via a prior gitops-manager commit and is preserved here.

## Motivation

No Go vulnerability scanning existed in CI. The \`govulncheck\` step surfaces known CVEs in the module's dependency graph before they reach \`develop\`. On first run it detected 15 real CVEs in the Go toolchain — issue #112 tracks the required toolchain upgrade (\`persona/developer\`).

## What changed

- Added \`govulncheck\` job (Vulnerability Scan) to \`.github/workflows/ci.yml\`
- All other CI jobs (lint, test, build, helm-lint, manifest-drift, secret scanning) are unchanged from \`develop\`

## Test plan

- [x] CI runs on this PR — 6/7 jobs passing
- [x] \`manifest-drift\` confirms no RBAC drift
- [x] \`govulncheck\` correctly identified 15 CVEs (real findings, tracked in #112)
- [ ] After #112 is resolved (Go toolchain upgrade), re-run govulncheck and confirm zero findings

## Blocked by

\#112 — developer must upgrade Go toolchain to clear CVE findings before this PR can merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)