### PR TITLE
chore: bump version to v0.1.0-alpha.2

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.1"
+const Version = "v0.1.0-alpha.2"


### PR DESCRIPTION
## Summary
- Updates `internal/version/version.go` to `v0.1.0-alpha.2` to match the release tag applied at the develop→main merge

## Test plan
- [x] `make test` passes (all packages green)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)