### PR TITLE
fix(losant): replace GET /me with GET /applications/{id} in Ping

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -116,7 +116,7 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	lc := r.LosantClient
 	if lc == nil {
 		var err error
-		lc, err = losant.NewHTTPClient(&secret)
+		lc, err = losant.NewHTTPClient(&secret, ls.Spec.ApplicationID)
 		if err != nil {
 			logger.Error(err, "failed to construct Losant client from secret")
 			return r.setDegraded(ctx, &ls, "LastSyncSucceeded", "InvalidSecret", err.Error())

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -46,8 +46,8 @@ const (
 
 // LosantClient manages Losant device lifecycle via the REST provisioning API.
 type LosantClient interface {
-	// Ping verifies that the Application API Token is valid by calling GET /me.
-	// Returns nil on success.
+	// Ping verifies that the Application API Token is valid by calling
+	// GET /applications/{applicationId}. Returns nil on success.
 	Ping(ctx context.Context) error
 
 	// EnsureClusterDevice creates or retrieves the Edge Compute device representing this cluster.
@@ -78,29 +78,33 @@ type Tag struct {
 
 // HTTPClient implements LosantClient using the Losant REST API.
 type HTTPClient struct {
-	token      string
-	httpClient *http.Client
+	token         string
+	applicationID string
+	httpClient    *http.Client
 }
 
-// NewHTTPClient constructs an HTTPClient from a provisioning Secret.
+// NewHTTPClient constructs an HTTPClient from a provisioning Secret and the target application ID.
 //
 // The Secret must contain:
 //   - "api-token" — Losant Application API Token (from Application > Security > API Tokens)
-func NewHTTPClient(secret *corev1.Secret) (*HTTPClient, error) {
+func NewHTTPClient(secret *corev1.Secret, applicationID string) (*HTTPClient, error) {
 	token, ok := secret.Data["api-token"]
 	if !ok {
 		return nil, fmt.Errorf("provisioning secret %s/%s missing key \"api-token\"",
 			secret.Namespace, secret.Name)
 	}
 	return &HTTPClient{
-		token:      string(token),
-		httpClient: &http.Client{Timeout: 30 * time.Second},
+		token:         string(token),
+		applicationID: applicationID,
+		httpClient:    &http.Client{Timeout: 30 * time.Second},
 	}, nil
 }
 
-// Ping verifies the Application API Token by calling GET /me.
+// Ping verifies the Application API Token by calling GET /applications/{applicationID}.
+// This endpoint is accessible to Application API Tokens (unlike GET /me, which is user-only).
 func (c *HTTPClient) Ping(ctx context.Context) error {
-	_, err := c.doRequest(ctx, http.MethodGet, apiBase+"/me", nil)
+	path := fmt.Sprintf("%s/applications/%s", apiBase, c.applicationID)
+	_, err := c.doRequest(ctx, http.MethodGet, path, nil)
 	return err
 }
 

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -54,7 +54,8 @@ func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error
 // HTTP behaviour without Kubernetes fixtures.
 func newTestHTTPClient(serverURL string) *HTTPClient {
 	return &HTTPClient{
-		token: "test-api-token",
+		token:         "test-api-token",
+		applicationID: "app-123",
 		httpClient: &http.Client{
 			Transport: &redirectTransport{serverURL: serverURL},
 		},
@@ -83,7 +84,7 @@ func TestNewHTTPClient_MissingAPIToken(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "losant-creds", Namespace: "default"},
 		Data:       map[string][]byte{"wrong-key": []byte("value")},
 	}
-	if _, err := NewHTTPClient(secret); err == nil {
+	if _, err := NewHTTPClient(secret, "app-456"); err == nil {
 		t.Error("NewHTTPClient with missing api-token: expected error, got nil")
 	}
 }
@@ -93,12 +94,15 @@ func TestNewHTTPClient_Success(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "losant-creds", Namespace: "default"},
 		Data:       map[string][]byte{"api-token": []byte("tok-abc")},
 	}
-	c, err := NewHTTPClient(secret)
+	c, err := NewHTTPClient(secret, "app-123")
 	if err != nil {
 		t.Fatalf("NewHTTPClient: unexpected error: %v", err)
 	}
 	if c.token != "tok-abc" {
 		t.Errorf("token: got %q, want %q", c.token, "tok-abc")
+	}
+	if c.applicationID != "app-123" {
+		t.Errorf("applicationID: got %q, want %q", c.applicationID, "app-123")
 	}
 }
 
@@ -106,8 +110,8 @@ func TestNewHTTPClient_Success(t *testing.T) {
 
 func TestPing_Success(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
-		writeJSON(w, map[string]string{"userId": "u-1"})
+	mux.HandleFunc("GET /applications/app-123", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]interface{}{"applicationId": "app-123"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -131,9 +135,9 @@ func TestPing_AuthFailure(t *testing.T) {
 func TestPing_BearerTokenSent(t *testing.T) {
 	var gotAuth string
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /applications/app-123", func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
-		writeJSON(w, map[string]string{"userId": "u-1"})
+		writeJSON(w, map[string]interface{}{"applicationId": "app-123"})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()


### PR DESCRIPTION
## Summary
- `Ping()` was calling `GET /me`, a user-only endpoint that rejects Application API Tokens with 403
- Added `applicationID string` to `HTTPClient` struct; `NewHTTPClient` now takes it as a second parameter
- `Ping` now calls `GET /applications/{applicationId}`, which Application API Tokens can access and which also validates the token against the specific application in `spec.applicationID`
- `LosantClient` interface is unchanged — no mock updates needed
- Test-engineer updated `client_test.go` (closes #108): `newTestHTTPClient` sets `applicationID`, constructor tests pass second arg, Ping tests stub `/applications/app-123` instead of `/me`

## Test plan
- [x] `go test ./internal/losant/... -v` — all tests pass
- [x] `go test ./internal/... -count=1` — all packages pass
- [x] `TestPing_Success` verifies Ping calls `/applications/app-123` (not `/me`)
- [x] `TestNewHTTPClient_Success` verifies `applicationID` is stored correctly

Closes #106, closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)