### PR TITLE
test(tdd): Ping must call GET /applications/{id}, not GET /me (issue #106)

### DIFF
--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -146,6 +146,29 @@ func TestPing_BearerTokenSent(t *testing.T) {
 	}
 }
 
+// TestPing_ApplicationEndpoint is a TDD spec for issue #106.
+// Application API Tokens are rejected by GET /me (403 Forbidden).
+// Ping must be fixed to call GET /applications/{applicationId} instead.
+//
+// This test fails against the current implementation and will pass once #106 is resolved.
+func TestPing_ApplicationEndpoint(t *testing.T) {
+	mux := http.NewServeMux()
+	// Simulate production: Application API Tokens get 403 on GET /me.
+	mux.HandleFunc("GET /me", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"type":"Forbidden","message":"Access is forbidden"}`, http.StatusForbidden)
+	})
+	// Any application-scoped path returns 200 — the expected endpoint after the fix.
+	mux.HandleFunc("/applications/", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]interface{}{"applicationId": "app-123"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).Ping(context.Background()); err != nil {
+		t.Fatalf("Ping: unexpected error: %v\n\tissue #106: Ping must use GET /applications/{id}, not GET /me", err)
+	}
+}
+
 // --- EnsureClusterDevice ---
 
 func TestEnsureClusterDevice_Found(t *testing.T) {


### PR DESCRIPTION
## Summary

TDD spec for issue #106. Adds `TestPing_ApplicationEndpoint` to `internal/losant/client_test.go`.

**This PR contains an intentionally failing test** — it is a spec for the developer working on #106, not a complete fix.

## What the test does

- Stubs `GET /me` to return `403 Forbidden` (mirroring production behaviour for Application API Tokens)
- Stubs `GET /applications/*` to return `200 OK`
- Asserts `Ping()` returns `nil`

**Current result:** FAIL — `status 403: Access is forbidden` (Ping calls `/me` which rejects app tokens)

**Expected result after #106 fix:** PASS — Ping calls `GET /applications/{applicationId}` which accepts app tokens

## For the developer fixing #106

1. Add `applicationID string` field to `HTTPClient` (or adjust Ping's signature)
2. Update `NewHTTPClient` to read/store the application ID
3. Update `Ping()` to call `GET /applications/{applicationId}` instead of `GET /me`
4. Update `newTestHTTPClient` helper to set `applicationID: "app-123"`
5. Update `TestPing_Success` and `TestPing_BearerTokenSent` to stub `/applications/app-123`

Once those changes are made, this PR can be rebased and merged alongside the developer's fix.

## Test plan
- [x] `TestPing_ApplicationEndpoint` fails against current code (as expected — documents the bug)
- [x] All other tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)