### PR TITLE
docs: document Step 4 Edge Workflow — HTTP Trigger setup and payload format

### DIFF
--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -55,18 +55,86 @@ The GEA pod needs its own credentials to authenticate to Losant as the Edge Comp
 
 ## Step 4: Create the Edge Workflow
 
-The GEA runs an Edge Workflow that receives metric payloads from the controller and routes them to the correct Losant devices.
+The GEA runs an Edge Workflow that receives state reports from the controller over HTTP and forwards them to Losant as device state. The controller POSTs one request per device (cluster device + one per node) on every sync cycle.
+
+> **Prerequisite**: The GEA pod must be running and connected to Losant before the Edge Compute device appears as a workflow target. If your device is not listed in the workflow creation dialog, verify the GEA pod is healthy and the device shows **Online** status in Losant before continuing.
+
+### Creating the workflow
 
 1. In your Application → **Workflows** → **Add Workflow** → **Edge Workflow**
-2. Select the Edge Compute device you created in Step 2
-3. Add an **HTTP Trigger** node (this receives POST requests from the controller on port 8080)
-4. Add logic to:
-   - Parse the incoming JSON payload (cluster state + per-node states)
-   - Use **Device: Set State** nodes to report cluster-level attributes to the cluster device
-   - Loop over node entries and use **Device: Set State** for each peripheral node device
-5. Save and deploy the workflow to the device
+2. Give the workflow a name (e.g., `k8s-state-receiver`)
+3. Under **Edge Devices**, select the Edge Compute device you created in Step 2
 
-> Note: The exact workflow structure depends on the payload format implemented by `internal/gea/payload.go`. See the payload format documentation once that package is implemented.
+> **Note on Device trigger blocks**: The Losant workflow editor shows cloud-side trigger nodes labelled "Device" (command, connect, disconnect, startup). These fire on MQTT events from a cloud perspective and are **not** what you need here. You need an **HTTP Trigger** node, which is an edge-side trigger that listens for local HTTP requests on the GEA pod.
+
+### Configuring the HTTP Trigger node
+
+4. In the workflow canvas, add an **HTTP Trigger** node
+5. Set the trigger path to `/state`
+6. Set the method to `POST`
+7. Leave the port at `8080` (the default; must match `LosantSync.spec.gea.port`)
+
+### Payload format
+
+The controller sends a separate POST for each device on every sync. The JSON body has this structure:
+
+```json
+{
+  "deviceId": "<losant-device-id>",
+  "time": "2026-04-29T12:00:00Z",
+  "data": { ... }
+}
+```
+
+The `time` field is omitted when the controller does not supply an explicit timestamp; the GEA then applies its own clock.
+
+**Cluster device payload** (`data` fields):
+
+| Field | Type | Description |
+|---|---|---|
+| `health_score` | number | Composite cluster health score (0–100) |
+| `health_status` | string | Human-readable summary (e.g. `Healthy`, `Degraded`) |
+| `total_nodes` | number | Total node count |
+| `ready_nodes` | number | Nodes in Ready state |
+| `unhealthy_nodes` | number | Nodes not in Ready state |
+| `total_pods` | number | Total pod count across all namespaces |
+| `running_pods` | number | Pods in Running phase |
+| `failed_pods` | number | Pods in Failed phase |
+| `pending_pods` | number | Pods in Pending phase |
+| `crashloop_pods` | number | Pods in CrashLoopBackOff |
+| `degraded_pvcs` | number | PersistentVolumeClaims not in Bound state |
+| `coredns_healthy` | boolean | `true` if all CoreDNS pods are Running |
+| `event_warnings` | number | Count of Warning-level events in the last observation window |
+
+**Node device payload** (`data` fields):
+
+| Field | Type | Description |
+|---|---|---|
+| `health_score` | number | Node health score (0–100) |
+| `health_status` | string | Human-readable summary |
+| `ready` | boolean | `true` if the node condition is Ready |
+| `memory_pressure` | boolean | `true` if MemoryPressure condition is active |
+| `disk_pressure` | boolean | `true` if DiskPressure condition is active |
+| `pid_pressure` | boolean | `true` if PIDPressure condition is active |
+| `pod_count` | number | Total pods scheduled on this node |
+| `not_ready_pods` | number | Pods on this node not in Running phase |
+| `crashloop_pods` | number | Pods on this node in CrashLoopBackOff |
+
+### Routing state to the correct device
+
+Because `deviceId` is included in every POST body, a single workflow handles both cluster and node state without branching on device type:
+
+8. From the HTTP Trigger, add a **Device: Set State** node
+9. Set the **Device** field to **Payload Path** and enter `data.body.deviceId`
+10. Set the **State** field to **Payload Path** and enter `data.body.data`
+11. Add a **HTTP Response** node after the Set State node; return status `200`
+
+### Deploying the workflow
+
+12. Save the workflow
+13. Click **Deploy** to push it to the Edge Compute device
+
+Once deployed, the GEA will start accepting state POSTs from the controller on `http://losant-gea:8080/state`.
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -8,26 +8,50 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 ## Prerequisites
 
-### Step 1 — Determine your run mode
+### Step 1 — Decide your run mode
 
-All subsequent steps branch on how the controller was started. Decide now:
+All subsequent steps branch on this decision. Pick one now:
 
-- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster
-- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace
+- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing.
+- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging and production.
 
-### Step 2 — Verify CRD is installed (all modes)
+### Step 2 — Install or verify the CRD (all modes)
 
 ```bash
 kubectl get crd losantsyncs.losant.io
 ```
 
-Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found, run `make manifests install`.
+Expected output shows `losantsyncs.losant.io` with a creation timestamp. If not found:
 
-### Step 3 — Verify controller is running
+```bash
+make manifests install
+```
+
+### Step 3 — Start the controller
+
+**If you chose `make run`:**
+
+```bash
+make run
+```
+
+The controller starts in your terminal and connects to the cluster in `~/.kube/config`. Keep this terminal open — logs appear here. No namespace or Deployment is created in the cluster.
+
+**If you chose `make deploy`:**
+
+```bash
+# Build and push your image first (set IMG to your registry)
+make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
+
+# Deploy controller + GEA to the losant-system namespace
+make deploy IMG=my-registry/losant-device:v0.x.y
+```
+
+### Step 4 — Verify the controller is running
 
 **If you used `make run`:**
 
-Controller logs appear in the terminal where `make run` is executing. No cluster checks are needed — there is no Deployment or namespace in the cluster.
+Controller logs appear in the terminal from Step 3. No cluster checks are needed.
 
 **If you used `make deploy`:**
 
@@ -38,16 +62,18 @@ kubectl logs -n losant-system deploy/losant-device-controller-manager -f
 
 ---
 
-## Deploying / Upgrading
+## Upgrading an Existing Deployment
+
+These commands apply only when the controller is already running via `make deploy` and you want to update it.
 
 ```bash
-# Build and push image (set IMG to your registry)
+# Build and push the new image
 make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
 
-# Deploy to cluster
+# Roll out the new image
 make deploy IMG=my-registry/losant-device:v0.x.y
 
-# Install / update CRDs only (no controller restart needed for CRD additions)
+# Update CRDs only (no controller restart needed for CRD additions)
 make install
 ```
 
@@ -103,6 +129,10 @@ make install
 ### Phase stuck at Provisioning
 
 1. Check controller logs for provisioning errors:
+
+   **If using `make run`:** look for `provision` in the terminal running the controller.
+
+   **If using `make deploy`:**
    ```bash
    kubectl logs -n losant-system deploy/losant-device-controller-manager | grep "provision"
    ```


### PR DESCRIPTION
## Summary

- Replaced the Step 4 placeholder with concrete instructions for creating an Edge Workflow in the Losant UI
- Documented the full JSON payload format (`deviceId`, `time`, `data`) sent by the controller to the GEA HTTP endpoint
- Added tables for all cluster-device and node-device `data` fields with types and descriptions
- Added prerequisite callout: GEA must be running/connected before the device appears in the workflow creation dialog
- Clarified that cloud-side "Device" trigger blocks (command/connect/disconnect/startup) are not what's needed — the edge-side **HTTP Trigger** node is required
- Documented the `Device: Set State` routing pattern using `data.body.deviceId` and `data.body.data` payload paths

Closes #101
Closes #102

## Test plan

- [ ] Review Step 4 narrative for accuracy against `internal/gea/client.go` wire format (`geaStateBody`) and `internal/controller/losantsync_controller.go` attribute maps (`clusterAttributes`, `nodeAttributes`)
- [ ] Verify payload field tables match `monitor.ClusterHealth` and `monitor.NodeHealth` struct fields
- [ ] Confirm endpoint path `/state` matches `NewHTTPClient` in `internal/gea/client.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)