### PR TITLE
fix: handle errcheck violations — discard resp.Body.Close() error

### DIFF
--- a/internal/gea/client.go
+++ b/internal/gea/client.go
@@ -91,7 +91,7 @@ func (c *HTTPClient) ReportState(ctx context.Context, payload StatePayload) erro
 	if err != nil {
 		return fmt.Errorf("gea post %s: %w", c.endpoint, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -234,7 +234,7 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload
 	if err != nil {
 		return nil, fmt.Errorf("losant api %s %s: %w", method, path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `internal/gea/client.go:94` and `internal/losant/client.go:237`: change `defer resp.Body.Close()` to `defer func() { _ = resp.Body.Close() }()` to explicitly discard the error and satisfy golangci-lint v2 `errcheck`

## Test plan
- [x] `make test` passes

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)