### PR TITLE
fix(losant): add gatewayId to peripheral device creation payload

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -147,7 +147,7 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		ls.Status.NodeDevices = make(map[string]string)
 	}
 	for nodeName := range nodeSnapshot {
-		nodeDeviceID, nodeErr := lc.EnsureNodeDevice(ctx, ls.Spec, nodeName)
+		nodeDeviceID, nodeErr := lc.EnsureNodeDevice(ctx, ls.Spec, nodeName, clusterDeviceID)
 		if nodeErr != nil {
 			logger.Error(nodeErr, "failed to ensure node device", "node", nodeName)
 			return r.setDegraded(ctx, &ls, "DevicesProvisioned", "NodeDeviceError",

--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -203,7 +203,7 @@ func TestEnsureNodeDeviceFailure(t *testing.T) {
 	hs := monitor.NewHealthStore()
 	hs.Update(monitor.ClusterHealth{}, map[string]monitor.NodeHealth{"bad-node": {}})
 	ml := losant.NewMockClient()
-	ml.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _ string) (string, error) {
+	ml.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _, _ string) (string, error) {
 		return "", errors.New("node api error")
 	}
 	mg := gea.NewMockClient()

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -54,7 +54,9 @@ type LosantClient interface {
 	EnsureClusterDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (deviceID string, err error)
 
 	// EnsureNodeDevice creates or retrieves the peripheral device for a k8s node.
-	EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (deviceID string, err error)
+	// gatewayID must be the Losant device ID of the cluster Edge Compute device;
+	// Losant requires peripheral devices to declare their gateway at creation time.
+	EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (deviceID string, err error)
 
 	// UpdateDeviceTags replaces the tag set on an existing Losant device.
 	UpdateDeviceTags(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
@@ -120,11 +122,11 @@ func (c *HTTPClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha
 	}
 
 	tags := tagsFromSpec(spec)
-	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, tags)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, "", tags)
 }
 
 // EnsureNodeDevice looks up the peripheral device for a node by name and creates it if absent.
-func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error) {
+func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error) {
 	name := nodeDeviceName(spec.ClusterName, nodeName)
 	existing, err := c.findDeviceByName(ctx, spec.ApplicationID, name)
 	if err != nil {
@@ -136,7 +138,7 @@ func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.L
 
 	tags := tagsFromSpec(spec)
 	tags = append(tags, Tag{Key: "nodeName", Value: nodeName})
-	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, tags)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, gatewayID, tags)
 }
 
 // UpdateDeviceTags replaces the tags on the given device.
@@ -189,7 +191,7 @@ func (c *HTTPClient) findDeviceByName(ctx context.Context, applicationID, name s
 }
 
 // createDevice POSTs a new device and returns the assigned device ID.
-func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID string, tags []Tag) (string, error) {
+func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID, gatewayID string, tags []Tag) (string, error) {
 	payload := map[string]interface{}{
 		"name":        name,
 		"deviceClass": class,
@@ -197,6 +199,9 @@ func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, clas
 	}
 	if recipeID != "" {
 		payload["deviceRecipeId"] = recipeID
+	}
+	if gatewayID != "" {
+		payload["gatewayId"] = gatewayID
 	}
 
 	path := fmt.Sprintf("%s/applications/%s/devices", apiBase, applicationID)

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -215,7 +215,7 @@ func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	id, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-1")
+	id, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-1", "gw-123")
 	if err != nil {
 		t.Fatalf("EnsureNodeDevice: %v", err)
 	}
@@ -223,15 +223,18 @@ func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 		t.Errorf("deviceID: got %q, want %q", id, "node-dev-id")
 	}
 	tags, _ := postBody["tags"].([]interface{})
-	found := false
+	foundNodeName := false
 	for _, tag := range tags {
 		m, _ := tag.(map[string]interface{})
 		if m["key"] == "nodeName" && m["value"] == "node-1" {
-			found = true
+			foundNodeName = true
 		}
 	}
-	if !found {
+	if !foundNodeName {
 		t.Errorf("expected nodeName=node-1 in POST tags, got: %v", tags)
+	}
+	if postBody["gatewayId"] != "gw-123" {
+		t.Errorf("gatewayId: got %v, want %q", postBody["gatewayId"], "gw-123")
 	}
 }
 

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -34,7 +34,7 @@ type MockClient struct {
 
 	PingFunc                func(ctx context.Context) error
 	EnsureClusterDeviceFunc func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error)
-	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error)
+	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error)
 	UpdateDeviceTagsFunc    func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
 	GetDeviceFunc           func(ctx context.Context, applicationID, deviceID string) (*Device, error)
 
@@ -53,8 +53,9 @@ type EnsureClusterDeviceCall struct {
 
 // EnsureNodeDeviceCall records one invocation of EnsureNodeDevice.
 type EnsureNodeDeviceCall struct {
-	Spec     losantv1alpha1.LosantSyncSpec
-	NodeName string
+	Spec      losantv1alpha1.LosantSyncSpec
+	NodeName  string
+	GatewayID string
 }
 
 // UpdateDeviceTagsCall records one invocation of UpdateDeviceTags.
@@ -89,7 +90,7 @@ func (m *MockClient) SetError(err error) {
 	m.EnsureClusterDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec) (string, error) {
 		return "", err
 	}
-	m.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _ string) (string, error) {
+	m.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _, _ string) (string, error) {
 		return "", err
 	}
 	m.UpdateDeviceTagsFunc = func(_ context.Context, _, _ string, _ map[string]string) error {
@@ -154,14 +155,14 @@ func (m *MockClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha
 }
 
 // EnsureNodeDevice implements LosantClient.
-func (m *MockClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error) {
+func (m *MockClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error) {
 	m.mu.Lock()
-	m.EnsureNodeDeviceCalls = append(m.EnsureNodeDeviceCalls, EnsureNodeDeviceCall{Spec: spec, NodeName: nodeName})
+	m.EnsureNodeDeviceCalls = append(m.EnsureNodeDeviceCalls, EnsureNodeDeviceCall{Spec: spec, NodeName: nodeName, GatewayID: gatewayID})
 	fn := m.EnsureNodeDeviceFunc
 	m.mu.Unlock()
 
 	if fn != nil {
-		return fn(ctx, spec, nodeName)
+		return fn(ctx, spec, nodeName, gatewayID)
 	}
 	return "mock-node-" + nodeName, nil
 }

--- a/internal/losant/mock_client_test.go
+++ b/internal/losant/mock_client_test.go
@@ -60,7 +60,7 @@ func TestMockClient_DefaultResponses(t *testing.T) {
 		t.Errorf("EnsureClusterDevice: got (%q, %v), want non-empty id and nil err", id, err)
 	}
 
-	nodeID, err := m.EnsureNodeDevice(ctx, baseSpec, "node-1")
+	nodeID, err := m.EnsureNodeDevice(ctx, baseSpec, "node-1", "gw-123")
 	if err != nil || nodeID == "" {
 		t.Errorf("EnsureNodeDevice: got (%q, %v), want non-empty id and nil err", nodeID, err)
 	}
@@ -84,10 +84,10 @@ func TestMockClient_CallsRecorded(t *testing.T) {
 	if _, err := m.EnsureClusterDevice(ctx, baseSpec); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-a"); err != nil {
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-a", "gw-123"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-b"); err != nil {
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-b", "gw-123"); err != nil {
 		t.Fatal(err)
 	}
 	if err := m.UpdateDeviceTags(ctx, "app-123", "dev-1", nil); err != nil {
@@ -122,7 +122,7 @@ func TestMockClient_SetError(t *testing.T) {
 	if _, err := m.EnsureClusterDevice(ctx, baseSpec); !errors.Is(err, want) {
 		t.Errorf("EnsureClusterDevice: got %v, want %v", err, want)
 	}
-	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "n"); !errors.Is(err, want) {
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "n", "gw-123"); !errors.Is(err, want) {
 		t.Errorf("EnsureNodeDevice: got %v, want %v", err, want)
 	}
 	if err := m.UpdateDeviceTags(ctx, "", "", nil); !errors.Is(err, want) {
@@ -172,7 +172,7 @@ func TestMockClient_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			_, _ = m.EnsureNodeDevice(ctx, baseSpec, "node")
+			_, _ = m.EnsureNodeDevice(ctx, baseSpec, "node", "gw-123")
 		}(i)
 	}
 	wg.Wait()


### PR DESCRIPTION
## Summary
- Peripheral (node) devices now include a `gatewayId` field in their creation payload so Losant can associate them with the cluster Edge Compute device (their gateway)
- `EnsureNodeDevice` interface gains a fourth `gatewayID string` parameter; controller passes `clusterDeviceID` as the gateway
- `MockClient`, `EnsureNodeDeviceCall`, and all test call sites updated for the new signature (closes #126)
- New test assertion: `TestEnsureNodeDevice_Created_WithNodeNameTag` now verifies `gatewayId` appears in the POST body

## Changes
**Developer (commit `54ca423`):**
- `internal/losant/client.go`: `EnsureNodeDevice` + `createDevice` accept `gatewayID`; payload includes `"gatewayId"` when non-empty
- `internal/controller/losantsync_controller.go`: passes `clusterDeviceID` as `gatewayID`

**Test engineer (commit `98b0c9c`):**
- `internal/losant/mock_client.go`: `EnsureNodeDeviceFunc`, `EnsureNodeDeviceCall.GatewayID`, `EnsureNodeDevice` method, `SetError` all updated
- `internal/losant/mock_client_test.go`: all `EnsureNodeDevice` calls pass `"gw-123"`
- `internal/losant/client_test.go`: `EnsureNodeDevice` call passes `"gw-123"`; new assertion on `gatewayId` in POST body
- `internal/controller/losantsync_controller_test.go`: `EnsureNodeDeviceFunc` closure updated to 4-arg signature

## Test plan
- [x] `go test ./internal/... -count=1` — all packages pass
- [x] `TestEnsureNodeDevice_Created_WithNodeNameTag` verifies `gatewayId` in POST body
- [x] Only `*_test.go` and `mock_client.go` modified by test engineer

Closes #124, closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)