### PR TITLE
release: merge develop into main

### DIFF
--- a/.claude/commands/persona-setup.md
+++ b/.claude/commands/persona-setup.md
@@ -1,0 +1,66 @@
+Set up this Go workspace for a new persona session. Follow these steps exactly, checking state before running anything.
+
+## Step 1 — Verify working directory
+
+Confirm we are in the `losant-device` repo root (a `go.mod` file must exist and the module line must read `github.com/mak3r/losant-device`). If not, stop and tell the user to `cd` to the correct directory.
+
+## Step 2 — Go module dependencies
+
+Check whether dependencies are already downloaded:
+```bash
+go mod verify 2>&1 | tail -5
+```
+- If the output ends with `all modules verified`, dependencies are present — skip to Step 3.
+- Otherwise run:
+  ```bash
+  go mod download
+  ```
+  Accept any prompts automatically; do not ask the user unless `go mod download` itself prompts for credentials.
+
+## Step 3 — Local toolchain binaries (`./bin/`)
+
+The project installs four tools into `./bin/`. Check each one:
+
+| Binary glob | Make target |
+|---|---|
+| `bin/controller-gen-*` | `make controller-gen` |
+| `bin/kustomize-*` | `make kustomize` |
+| `bin/setup-envtest-*` | `make envtest` |
+| `bin/golangci-lint-*` | `make golangci-lint` |
+
+Run `ls bin/` (or note the directory doesn't exist yet). For each missing tool, run its `make` target. You can run all missing targets in a single `make` invocation, for example:
+```bash
+make controller-gen kustomize envtest golangci-lint
+```
+Only include targets whose binary glob is absent.
+
+## Step 4 — Envtest Kubernetes assets
+
+The test suite needs a specific Kubernetes API server binary bundle. Check whether it has been downloaded:
+```bash
+./bin/setup-envtest list --bin-path ./bin 2>/dev/null | grep "1.31.0" || echo "not downloaded"
+```
+If not downloaded, fetch it:
+```bash
+./bin/setup-envtest use 1.31.0 --bin-path ./bin
+```
+This may take a moment; wait for it to complete.
+
+## Step 5 — Smoke check
+
+Run a quick build verification to confirm everything is wired up:
+```bash
+go build ./...
+```
+Report success or any errors to the user. If errors occur, diagnose them and fix (e.g. missing `go mod tidy`) before declaring setup complete.
+
+## Step 6 — Report
+
+Print a concise summary:
+- Go version (`go version`)
+- Module verification status
+- Which tools were already present vs. freshly installed
+- Whether envtest assets were already present vs. downloaded
+- Whether `go build ./...` passed
+
+Do not ask the user for confirmation between steps unless a command exits non-zero with an error that requires a decision.

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -1,0 +1,94 @@
+Review open GitHub issues and PRs for a persona, optionally looping until a session deadline.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` as one of:
+
+| Form | Meaning |
+|---|---|
+| `<persona>` | Single check, then stop |
+| `<persona> <minutes>` | Loop every ~4.5 min for `<minutes>` minutes |
+| `<persona> until:<iso_timestamp>` | Loop until absolute deadline (used by self-scheduling wake-ups) |
+
+Valid persona names: `developer`, `test-engineer`, `security`, `qa`, `gitops-manager`, `docs`, `merge-manager`, `product-designer`
+
+On first call with `<minutes>`, compute `end_time = now + <minutes> minutes` as an ISO 8601 UTC string (e.g. `2026-04-30T16:00:00Z`). All subsequent self-scheduled wake-ups pass `until:<end_time>` so the deadline survives across sessions.
+
+---
+
+## Work-Check Cycle (run once per wake-up)
+
+### 1 — Open issues for this persona
+
+```bash
+gh issue list \
+  --state open \
+  --label "persona/<persona-name>" \
+  --json number,title,updatedAt \
+  --limit 25 \
+  --jq '.[] | "#\(.number)  \(.title)  [updated \(.updatedAt[:10])]"'
+```
+
+Print the results verbatim. If there are zero results, print `  (none)`.
+
+Only fetch an issue's full body (`gh issue view <n>`) if the user asks you to act on it or if you need the body to determine what action is required. Do **not** read it proactively.
+
+### 2 — PRs needing this persona's attention
+
+```bash
+gh pr list \
+  --state open \
+  --json number,title,headRefName,reviewDecision,comments,requestedReviewers \
+  --limit 30 \
+  --jq '[.[] | select(
+      (.headRefName | startswith("feature/developer/")) or
+      (.headRefName | startswith("persona/")) or
+      (.requestedReviewers | length > 0)
+  )] | .[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  comments:\(.comments | length)"'
+```
+
+Print results verbatim. For each PR that shows `review:CHANGES_REQUESTED` or `comments:` > 0, add a note: `  → fetch comments with: gh pr view <n> --comments` but do **not** fetch them automatically. Only fetch comments if you need to understand what to address.
+
+### 3 — Output format
+
+```
+=== watch-work: <persona> @ <HH:MM UTC> | session ends <HH:MM UTC or "single check"> ===
+ISSUES (<N> open):
+  #42  Fix provisioner crash  [updated 2026-04-29]
+  #57  Add node label support [updated 2026-04-28]
+
+PRs (<N>):
+  #17  "Add node metrics" [feature/developer/node-metrics]  review:CHANGES_REQUESTED  comments:3
+    → fetch comments with: gh pr view 17 --comments
+
+===
+```
+
+If both sections are empty: `No open issues or PR activity for <persona> @ <HH:MM>. Next check: <HH:MM> (or "done").`
+
+---
+
+## Self-Scheduling Logic
+
+After printing the report:
+
+**If running in single-check mode** (no duration given): stop here. Output nothing more.
+
+**If running in watch mode**:
+- Check: is `now < end_time`?
+- **Yes** → call `ScheduleWakeup` with:
+  - `delaySeconds`: 270 (4.5 min — stays inside the 5-min prompt-cache window)
+  - `reason`: `"Polling issues/PRs for <persona> (session ends <end_time>)"`
+  - `prompt`: `/watch-work <persona> until:<end_time_iso>`
+- **No** → output: `Watch session complete for <persona>. Ran until <end_time_iso>.` and stop.
+
+---
+
+## Token Efficiency Rules
+
+1. **Fetch only named fields.** Every `gh` call must include `--json <field-list>`. Never omit the field list.
+2. **Filter with `--jq`.** Use the `--jq` expressions above so only the formatted strings reach your context, not raw JSON objects.
+3. **Never read local repo files** during a watch cycle unless the user explicitly asks.
+4. **Never quote issue or PR body verbatim** unless directly asked. Summarise in one line if action is needed.
+5. **One issue-list call and one PR-list call per cycle.** Do not make additional API calls unless the user asks you to act on a specific item.
+6. **Report concisely.** One line per issue, one line per PR. No preamble, no trailing explanation.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -126,6 +126,14 @@ make install
 
 ## Diagnosing Phase Problems
 
+**Start here for any stuck phase** — read the conditions first:
+
+```bash
+kubectl get losantsync my-cluster -o jsonpath='{.status.conditions}' | python3 -m json.tool
+```
+
+Each condition has a `reason` and `message` that identify exactly which step failed. Use the sections below to dig further based on what you see.
+
 ### Phase stuck at Provisioning
 
 1. Check controller logs for provisioning errors:
@@ -140,11 +148,7 @@ make install
    ```bash
    kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.api-token}' | base64 -d
    ```
-3. Check `DevicesProvisioned` condition for a reason:
-   ```bash
-   kubectl get losantsync my-cluster -o jsonpath='{.status.conditions}'
-   ```
-4. Confirm the Losant REST API is reachable from within the cluster:
+3. Confirm the Losant REST API is reachable from within the cluster:
    ```bash
    kubectl run -it --rm curl-test --image=curlimages/curl --restart=Never -- \
      curl -I https://api.losant.com
@@ -152,21 +156,22 @@ make install
 
 ### Phase stuck at Degraded
 
-1. Check `GEAReachable` condition:
-   ```bash
-   kubectl get losantsync my-cluster \
-     -o jsonpath='{range .status.conditions[?(@.type=="GEAReachable")]}{.status}: {.reason} — {.message}{end}'
-   ```
-2. Verify the GEA pod is running:
+Degraded is set whenever any reconcile step fails — including provisioning steps. Always check the conditions first (above) to determine whether the failure is in provisioning (`DevicesProvisioned: False`) or GEA reporting (`GEAReachable: False`) before proceeding.
+
+**If `DevicesProvisioned` is False:** follow the Provisioning steps above.
+
+**If `GEAReachable` is False:**
+
+1. Verify the GEA pod is running:
    ```bash
    kubectl get pod -n losant-system -l app=losant-gea
    ```
-3. Test GEA HTTP trigger from within the cluster:
+2. Test GEA HTTP trigger from within the cluster:
    ```bash
    kubectl run -it --rm curl-test --image=curlimages/curl --restart=Never -- \
      curl -v http://losant-gea:8080
    ```
-4. Check GEA pod logs for MQTT connectivity issues:
+3. Check GEA pod logs for MQTT connectivity issues:
    ```bash
    kubectl logs -n losant-system -l app=losant-gea --tail=50
    ```

--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -147,7 +147,7 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		ls.Status.NodeDevices = make(map[string]string)
 	}
 	for nodeName := range nodeSnapshot {
-		nodeDeviceID, nodeErr := lc.EnsureNodeDevice(ctx, ls.Spec, nodeName)
+		nodeDeviceID, nodeErr := lc.EnsureNodeDevice(ctx, ls.Spec, nodeName, clusterDeviceID)
 		if nodeErr != nil {
 			logger.Error(nodeErr, "failed to ensure node device", "node", nodeName)
 			return r.setDegraded(ctx, &ls, "DevicesProvisioned", "NodeDeviceError",

--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -203,7 +203,7 @@ func TestEnsureNodeDeviceFailure(t *testing.T) {
 	hs := monitor.NewHealthStore()
 	hs.Update(monitor.ClusterHealth{}, map[string]monitor.NodeHealth{"bad-node": {}})
 	ml := losant.NewMockClient()
-	ml.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _ string) (string, error) {
+	ml.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _, _ string) (string, error) {
 		return "", errors.New("node api error")
 	}
 	mg := gea.NewMockClient()

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -54,7 +54,9 @@ type LosantClient interface {
 	EnsureClusterDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (deviceID string, err error)
 
 	// EnsureNodeDevice creates or retrieves the peripheral device for a k8s node.
-	EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (deviceID string, err error)
+	// gatewayID must be the Losant device ID of the cluster Edge Compute device;
+	// Losant requires peripheral devices to declare their gateway at creation time.
+	EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (deviceID string, err error)
 
 	// UpdateDeviceTags replaces the tag set on an existing Losant device.
 	UpdateDeviceTags(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
@@ -120,11 +122,11 @@ func (c *HTTPClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha
 	}
 
 	tags := tagsFromSpec(spec)
-	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, tags)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, "", tags)
 }
 
 // EnsureNodeDevice looks up the peripheral device for a node by name and creates it if absent.
-func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error) {
+func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error) {
 	name := nodeDeviceName(spec.ClusterName, nodeName)
 	existing, err := c.findDeviceByName(ctx, spec.ApplicationID, name)
 	if err != nil {
@@ -136,7 +138,7 @@ func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.L
 
 	tags := tagsFromSpec(spec)
 	tags = append(tags, Tag{Key: "nodeName", Value: nodeName})
-	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, tags)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, gatewayID, tags)
 }
 
 // UpdateDeviceTags replaces the tags on the given device.
@@ -189,7 +191,7 @@ func (c *HTTPClient) findDeviceByName(ctx context.Context, applicationID, name s
 }
 
 // createDevice POSTs a new device and returns the assigned device ID.
-func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID string, tags []Tag) (string, error) {
+func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID, gatewayID string, tags []Tag) (string, error) {
 	payload := map[string]interface{}{
 		"name":        name,
 		"deviceClass": class,
@@ -197,6 +199,9 @@ func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, clas
 	}
 	if recipeID != "" {
 		payload["deviceRecipeId"] = recipeID
+	}
+	if gatewayID != "" {
+		payload["gatewayId"] = gatewayID
 	}
 
 	path := fmt.Sprintf("%s/applications/%s/devices", apiBase, applicationID)

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -215,7 +215,7 @@ func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	id, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-1")
+	id, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-1", "gw-123")
 	if err != nil {
 		t.Fatalf("EnsureNodeDevice: %v", err)
 	}
@@ -223,15 +223,18 @@ func TestEnsureNodeDevice_Created_WithNodeNameTag(t *testing.T) {
 		t.Errorf("deviceID: got %q, want %q", id, "node-dev-id")
 	}
 	tags, _ := postBody["tags"].([]interface{})
-	found := false
+	foundNodeName := false
 	for _, tag := range tags {
 		m, _ := tag.(map[string]interface{})
 		if m["key"] == "nodeName" && m["value"] == "node-1" {
-			found = true
+			foundNodeName = true
 		}
 	}
-	if !found {
+	if !foundNodeName {
 		t.Errorf("expected nodeName=node-1 in POST tags, got: %v", tags)
+	}
+	if postBody["gatewayId"] != "gw-123" {
+		t.Errorf("gatewayId: got %v, want %q", postBody["gatewayId"], "gw-123")
 	}
 }
 

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -34,7 +34,7 @@ type MockClient struct {
 
 	PingFunc                func(ctx context.Context) error
 	EnsureClusterDeviceFunc func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error)
-	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error)
+	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error)
 	UpdateDeviceTagsFunc    func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
 	GetDeviceFunc           func(ctx context.Context, applicationID, deviceID string) (*Device, error)
 
@@ -53,8 +53,9 @@ type EnsureClusterDeviceCall struct {
 
 // EnsureNodeDeviceCall records one invocation of EnsureNodeDevice.
 type EnsureNodeDeviceCall struct {
-	Spec     losantv1alpha1.LosantSyncSpec
-	NodeName string
+	Spec      losantv1alpha1.LosantSyncSpec
+	NodeName  string
+	GatewayID string
 }
 
 // UpdateDeviceTagsCall records one invocation of UpdateDeviceTags.
@@ -89,7 +90,7 @@ func (m *MockClient) SetError(err error) {
 	m.EnsureClusterDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec) (string, error) {
 		return "", err
 	}
-	m.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _ string) (string, error) {
+	m.EnsureNodeDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec, _, _ string) (string, error) {
 		return "", err
 	}
 	m.UpdateDeviceTagsFunc = func(_ context.Context, _, _ string, _ map[string]string) error {
@@ -154,14 +155,14 @@ func (m *MockClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha
 }
 
 // EnsureNodeDevice implements LosantClient.
-func (m *MockClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName string) (string, error) {
+func (m *MockClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error) {
 	m.mu.Lock()
-	m.EnsureNodeDeviceCalls = append(m.EnsureNodeDeviceCalls, EnsureNodeDeviceCall{Spec: spec, NodeName: nodeName})
+	m.EnsureNodeDeviceCalls = append(m.EnsureNodeDeviceCalls, EnsureNodeDeviceCall{Spec: spec, NodeName: nodeName, GatewayID: gatewayID})
 	fn := m.EnsureNodeDeviceFunc
 	m.mu.Unlock()
 
 	if fn != nil {
-		return fn(ctx, spec, nodeName)
+		return fn(ctx, spec, nodeName, gatewayID)
 	}
 	return "mock-node-" + nodeName, nil
 }

--- a/internal/losant/mock_client_test.go
+++ b/internal/losant/mock_client_test.go
@@ -60,7 +60,7 @@ func TestMockClient_DefaultResponses(t *testing.T) {
 		t.Errorf("EnsureClusterDevice: got (%q, %v), want non-empty id and nil err", id, err)
 	}
 
-	nodeID, err := m.EnsureNodeDevice(ctx, baseSpec, "node-1")
+	nodeID, err := m.EnsureNodeDevice(ctx, baseSpec, "node-1", "gw-123")
 	if err != nil || nodeID == "" {
 		t.Errorf("EnsureNodeDevice: got (%q, %v), want non-empty id and nil err", nodeID, err)
 	}
@@ -84,10 +84,10 @@ func TestMockClient_CallsRecorded(t *testing.T) {
 	if _, err := m.EnsureClusterDevice(ctx, baseSpec); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-a"); err != nil {
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-a", "gw-123"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-b"); err != nil {
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "node-b", "gw-123"); err != nil {
 		t.Fatal(err)
 	}
 	if err := m.UpdateDeviceTags(ctx, "app-123", "dev-1", nil); err != nil {
@@ -122,7 +122,7 @@ func TestMockClient_SetError(t *testing.T) {
 	if _, err := m.EnsureClusterDevice(ctx, baseSpec); !errors.Is(err, want) {
 		t.Errorf("EnsureClusterDevice: got %v, want %v", err, want)
 	}
-	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "n"); !errors.Is(err, want) {
+	if _, err := m.EnsureNodeDevice(ctx, baseSpec, "n", "gw-123"); !errors.Is(err, want) {
 		t.Errorf("EnsureNodeDevice: got %v, want %v", err, want)
 	}
 	if err := m.UpdateDeviceTags(ctx, "", "", nil); !errors.Is(err, want) {
@@ -172,7 +172,7 @@ func TestMockClient_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			_, _ = m.EnsureNodeDevice(ctx, baseSpec, "node")
+			_, _ = m.EnsureNodeDevice(ctx, baseSpec, "node", "gw-123")
 		}(i)
 	}
 	wg.Wait()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.2"
+const Version = "v0.1.0-alpha.4"


### PR DESCRIPTION
## Summary

Brings main up to date with develop since v0.1.0-alpha.3:

- **gatewayId fix** (#124, PR be287d4): `EnsureNodeDevice` now passes `gatewayId` when creating peripheral devices — Losant requires this for all peripheral device creation
- **Runbook diagnostics** (PR 52e5275): conditions check added as first step in phase diagnostics; Degraded section now branches on `DevicesProvisioned` vs `GEAReachable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)