### PR TITLE
docs: use published ghcr.io image in runbook; fix Ping endpoint in architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ Uses `github.com/robfig/cron/v3` to compute the next fire time from either `spec
 
 On each scheduled reconcile, `LosantSyncReconciler` executes in order:
 
-1. **Ping** (`lc.Ping`) — verifies the Application API Token via `GET /me`; sets `phase=Degraded` on failure
+1. **Ping** (`lc.Ping`) — verifies the Application API Token via `GET /applications/{id}`; sets `phase=Degraded` on failure
 2. **EnsureClusterDevice** (`lc.EnsureClusterDevice`) — creates or retrieves the Edge Compute device; stores device ID in `Status.ClusterDeviceID`; sets `phase=Degraded` on failure
 3. **EnsureNodeDevice** per node in HealthStore (`lc.EnsureNodeDevice`) — creates or retrieves peripheral devices; sets `phase=Degraded` on first failure
 4. **ReportState cluster** (`gc.ReportState`) — POSTs cluster-level metrics to GEA HTTP endpoint; sets `phase=Degraded` on failure

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -12,8 +12,8 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 All subsequent steps branch on this decision. Pick one now:
 
-- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing.
-- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging and production.
+- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing. **Limitation**: cannot reach in-cluster Services (e.g., `losant-gea`), so GEA state reporting always fails. Provisioning steps work, but no metrics will be delivered to Losant.
+- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging, production, and any end-to-end testing that includes GEA metric reporting. Uses the published image at `ghcr.io/mak3r/losant-device` — no Docker build required.
 
 ### Step 2 — Install or verify the CRD (all modes)
 
@@ -40,12 +40,17 @@ The controller starts in your terminal and connects to the cluster in `~/.kube/c
 **If you chose `make deploy`:**
 
 ```bash
-# Build and push your image first (set IMG to your registry)
-make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
-
-# Deploy controller + GEA to the losant-system namespace
-make deploy IMG=my-registry/losant-device:v0.x.y
+# Deploy controller + GEA using the published image
+make deploy IMG=ghcr.io/mak3r/losant-device:latest
 ```
+
+> Available image tags: https://github.com/mak3r/losant-device/pkgs/container/losant-device
+>
+> If you have modified the controller source and want to test your changes, build and push your own image first:
+> ```bash
+> make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
+> make deploy IMG=my-registry/losant-device:v0.x.y
+> ```
 
 ### Step 4 — Verify the controller is running
 
@@ -67,15 +72,14 @@ kubectl logs -n losant-system deploy/losant-device-controller-manager -f
 These commands apply only when the controller is already running via `make deploy` and you want to update it.
 
 ```bash
-# Build and push the new image
-make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
-
-# Roll out the new image
-make deploy IMG=my-registry/losant-device:v0.x.y
+# Roll out a new published image
+make deploy IMG=ghcr.io/mak3r/losant-device:<new-tag>
 
 # Update CRDs only (no controller restart needed for CRD additions)
 make install
 ```
+
+> If upgrading from a custom-built image, run `make docker-build docker-push IMG=<your-registry>/losant-device:<new-tag>` first, then `make deploy IMG=<your-registry>/losant-device:<new-tag>`.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Runbook Step 1**: Documents the `make run` GEA limitation explicitly; clarifies `make deploy` uses the published image with no Docker build required (closes #136)
- **Runbook Step 3**: Replaces `make docker-build docker-push` + custom registry as the primary `make deploy` path with `make deploy IMG=ghcr.io/mak3r/losant-device:latest`; moves custom-build to a secondary developer note
- **Runbook Upgrading**: Same treatment — published image is now the primary upgrade path
- **architecture.md**: Corrects the Ping reconcile step from `GET /me` (returns 403 for Application API Tokens) to `GET /applications/{id}` (closes #135)

## Test plan

- [ ] Verify runbook Step 1 clearly communicates the `make run` GEA limitation
- [ ] Verify Step 3 `make deploy` path requires no Docker build steps
- [ ] Verify architecture.md Reconcile Sequence step 1 matches the code in `internal/losant/client.go`
- [ ] Confirm link to ghcr.io package page is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)