### PR TITLE
fix(lint): resolve golangci-lint v2 errcheck and staticcheck violations in test files

### DIFF
--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -150,7 +150,7 @@ var _ = Describe("LosantSync scheduling", func() {
 			second := getLosantSync(ctx, name).Status.NextScheduledTime
 			// NextScheduledTime must advance by approximately the interval.
 			// 3s tolerance accounts for reconcile scheduling jitter.
-			Expect(second.Time).To(BeTemporally("~", first.Time.Add(syncInterval), 3*time.Second))
+			Expect(second.Time).To(BeTemporally("~", first.Add(syncInterval), 3*time.Second))
 		})
 
 		// AC-SCHED-06: cron-based NextScheduledTime advances to next cron tick after each sync.
@@ -174,7 +174,7 @@ var _ = Describe("LosantSync scheduling", func() {
 
 			second := getLosantSync(ctx, name).Status.NextScheduledTime
 			// Next tick for "* * * * *" is ~60s from the previous tick; allow 10s tolerance.
-			Expect(second.Time).To(BeTemporally("~", first.Time.Add(time.Minute), 10*time.Second))
+			Expect(second.Time).To(BeTemporally("~", first.Add(time.Minute), 10*time.Second))
 		})
 
 		// AC-SCHED-08/09/10: controller restart behaviour.

--- a/test/testenv/credentials.go
+++ b/test/testenv/credentials.go
@@ -82,7 +82,7 @@ func LoadCredentials() (Credentials, bool) {
 	// If any field is missing, try the local file.
 	if !creds.Complete() {
 		if file, err := os.Open(envFilePath()); err == nil {
-			defer file.Close()
+			defer func() { _ = file.Close() }()
 			overrides := parseEnvFile(file)
 			if creds.ApplicationID == "" {
 				creds.ApplicationID = overrides["LOSANT_APPLICATION_ID"]

--- a/test/testenv/credentials_test.go
+++ b/test/testenv/credentials_test.go
@@ -129,6 +129,6 @@ func writeTempFile(t *testing.T, content string) *os.File {
 	if err != nil {
 		t.Fatalf("writeTempFile open: %v", err)
 	}
-	t.Cleanup(func() { f.Close() })
+	t.Cleanup(func() { _ = f.Close() })
 	return f
 }


### PR DESCRIPTION
## Summary

- **errcheck** `test/testenv/credentials.go:85` — `defer file.Close()` → `defer func() { _ = file.Close() }()`
- **errcheck** `test/testenv/credentials_test.go:132` — `t.Cleanup(func() { f.Close() })` → `t.Cleanup(func() { _ = f.Close() })`
- **staticcheck QF1008** `test/e2e/scheduling_test.go:153,177` — `first.Time.Add(...)` → `first.Add(...)` (remove redundant embedded-field selector; `Add` is promoted from `time.Time` on `*metav1.Time`)

Closes #123. Exposed by PR #120 (golangci-lint v2 upgrade).

## Test plan

- [ ] `make lint` passes locally with golangci-lint v2
- [ ] `make test` passes (unit + integration, no cluster required)
- [ ] No regressions in `test/testenv` or `test/e2e` packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)