### PR TITLE
release: v0.1.0-alpha.5

### DIFF
--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -1,4 +1,4 @@
-Review open GitHub issues and PRs for a persona, optionally looping until a session deadline.
+Adopt the persona named in $ARGUMENTS and work through open issues and PRs until the session ends or no work remains.
 
 ## Argument Parsing
 
@@ -6,35 +6,40 @@ Parse `$ARGUMENTS` as one of:
 
 | Form | Meaning |
 |---|---|
-| `<persona>` | Single check, then stop |
-| `<persona> <minutes>` | Loop every ~4.5 min for `<minutes>` minutes |
-| `<persona> until:<iso_timestamp>` | Loop until absolute deadline (used by self-scheduling wake-ups) |
+| `<persona>` | Work through items once, then stop |
+| `<persona> <minutes>` | Work continuously, polling every ~4.5 min for `<minutes>` minutes |
+| `<persona> until:<iso_timestamp>` | Work continuously until absolute deadline (used by self-scheduling wake-ups) |
 
 Valid persona names: `developer`, `test-engineer`, `security`, `qa`, `gitops-manager`, `docs`, `merge-manager`, `product-designer`
 
-On first call with `<minutes>`, compute `end_time = now + <minutes> minutes` as an ISO 8601 UTC string (e.g. `2026-04-30T16:00:00Z`). All subsequent self-scheduled wake-ups pass `until:<end_time>` so the deadline survives across sessions.
+On first call with `<minutes>`, compute `end_time = now + <minutes> minutes` as ISO 8601 UTC. Subsequent self-scheduled wake-ups pass `until:<end_time>` to preserve the deadline.
 
 ---
 
-## Work-Check Cycle (run once per wake-up)
+## Step 1 — Adopt the Persona
 
-### 1 — Open issues for this persona
+You ARE the `<persona>`. Read `CLAUDE.md` now to confirm:
+- Which files you are allowed to modify
+- Which branch you operate on
+- Any hard rules that apply to this persona
 
+Confirm the current branch matches your persona's branch. If not, tell the user which branch to switch to and stop.
+
+---
+
+## Step 2 — Scan for Work (token-efficient, one pass)
+
+**Open issues assigned to this persona:**
 ```bash
 gh issue list \
   --state open \
   --label "persona/<persona-name>" \
-  --json number,title,updatedAt \
+  --json number,title,labels,updatedAt \
   --limit 25 \
-  --jq '.[] | "#\(.number)  \(.title)  [updated \(.updatedAt[:10])]"'
+  --jq '.[] | "#\(.number)  \(.title)  \([.labels[].name] | join(","))  [updated \(.updatedAt[:10])]"'
 ```
 
-Print the results verbatim. If there are zero results, print `  (none)`.
-
-Only fetch an issue's full body (`gh issue view <n>`) if the user asks you to act on it or if you need the body to determine what action is required. Do **not** read it proactively.
-
-### 2 — PRs needing this persona's attention
-
+**Open PRs needing this persona's attention:**
 ```bash
 gh pr list \
   --state open \
@@ -47,48 +52,78 @@ gh pr list \
   )] | .[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  comments:\(.comments | length)"'
 ```
 
-Print results verbatim. For each PR that shows `review:CHANGES_REQUESTED` or `comments:` > 0, add a note: `  → fetch comments with: gh pr view <n> --comments` but do **not** fetch them automatically. Only fetch comments if you need to understand what to address.
-
-### 3 — Output format
-
-```
-=== watch-work: <persona> @ <HH:MM UTC> | session ends <HH:MM UTC or "single check"> ===
-ISSUES (<N> open):
-  #42  Fix provisioner crash  [updated 2026-04-29]
-  #57  Add node label support [updated 2026-04-28]
-
-PRs (<N>):
-  #17  "Add node metrics" [feature/developer/node-metrics]  review:CHANGES_REQUESTED  comments:3
-    → fetch comments with: gh pr view 17 --comments
-
-===
-```
-
-If both sections are empty: `No open issues or PR activity for <persona> @ <HH:MM>. Next check: <HH:MM> (or "done").`
+Print the results as a brief queue, then proceed to Step 3.
 
 ---
 
-## Self-Scheduling Logic
+## Step 3 — Pick the Highest-Priority Item
 
-After printing the report:
+Score every item in the queue and pick the highest. In case of a tie, prefer the oldest `updatedAt`.
 
-**If running in single-check mode** (no duration given): stop here. Output nothing more.
+| Priority | Condition |
+|---|---|
+| 1 | PR on your branch with `review:CHANGES_REQUESTED` — blocking a merge |
+| 2 | PR where you are a requested reviewer — blocking the PR author |
+| 3 | Issue labeled `type/bug` + `phase/1` |
+| 4 | Issue labeled `type/bug` + `phase/2` (or higher) |
+| 5 | Issue labeled `type/task` + `phase/1` |
+| 6 | Issue labeled `type/task` + `phase/2` (or higher) |
+| 7 | Anything else, oldest `updatedAt` first |
 
-**If running in watch mode**:
-- Check: is `now < end_time`?
-- **Yes** → call `ScheduleWakeup` with:
-  - `delaySeconds`: 270 (4.5 min — stays inside the 5-min prompt-cache window)
-  - `reason`: `"Polling issues/PRs for <persona> (session ends <end_time>)"`
-  - `prompt`: `/watch-work <persona> until:<end_time_iso>`
-- **No** → output: `Watch session complete for <persona>. Ran until <end_time_iso>.` and stop.
+To extract phase from an issue's labels: look for a label matching `phase/<n>` and read `<n>` as an integer. If no phase label is present, treat it as phase 99 (lowest).
+
+If the queue is empty, go to Step 5.
+
+---
+
+## Step 4 — Do the Work
+
+For the selected item:
+
+1. **Fetch full details:**
+   - Issue: `gh issue view <n>`
+   - PR: `gh pr view <n> --comments`
+
+2. **Understand what's needed.** Read only the files required to complete the task — do not explore the codebase broadly.
+
+3. **Make the changes** within your persona's designated file scope (from CLAUDE.md). Do not touch files owned by other personas.
+
+4. **Validate:**
+   - If you modified `*.go` files: `make test`
+   - If you modified manifests: `make manifests && git diff --exit-code config/rbac/role.yaml`
+   - Docs/YAML changes: no build step required
+
+5. **Commit** using conventional commit style:
+   ```
+   <type>(<scope>): <description>
+   
+   Closes #<issue-number>
+   
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+   ```
+
+6. **Update the issue/PR:** comment with a one-line summary of what was done and link the commit SHA.
+
+---
+
+## Step 5 — Loop or Schedule
+
+After completing an item (or finding an empty queue):
+
+**Single-check mode** (no duration): stop and print a summary of what was completed.
+
+**Watch mode:**
+- Is `now < end_time`?
+  - **Yes and work was just completed**: immediately return to Step 2 to check for more work.
+  - **Yes and queue was empty**: call `ScheduleWakeup` with `delaySeconds: 270`, `reason: "Polling for new work for <persona>"`, `prompt: "/watch-work <persona> until:<end_time_iso>"`
+  - **No**: print `Session complete for <persona>. Items completed this session: <N>.` and stop.
 
 ---
 
 ## Token Efficiency Rules
 
-1. **Fetch only named fields.** Every `gh` call must include `--json <field-list>`. Never omit the field list.
-2. **Filter with `--jq`.** Use the `--jq` expressions above so only the formatted strings reach your context, not raw JSON objects.
-3. **Never read local repo files** during a watch cycle unless the user explicitly asks.
-4. **Never quote issue or PR body verbatim** unless directly asked. Summarise in one line if action is needed.
-5. **One issue-list call and one PR-list call per cycle.** Do not make additional API calls unless the user asks you to act on a specific item.
-6. **Report concisely.** One line per issue, one line per PR. No preamble, no trailing explanation.
+1. `--json <field-list>` on every `gh` call — never omit the field list.
+2. `--jq` on every list call — only formatted strings reach context, not raw JSON.
+3. Read only files needed for the current task — no broad codebase exploration.
+4. Never quote issue or PR body verbatim unless it is directly relevant to a code decision.
+5. One issue-list call and one PR-list call per scan cycle.

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -12,6 +12,12 @@ Parse `$ARGUMENTS` as one of:
 
 Valid persona names: `developer`, `test-engineer`, `security`, `qa`, `gitops-manager`, `docs`, `merge-manager`, `product-designer`
 
+If the persona name is not in that list, stop immediately and print:
+```
+Unknown persona: "<name>". Valid personas: developer, test-engineer, security, qa, gitops-manager, docs, merge-manager, product-designer
+```
+Do not proceed further.
+
 On first call with `<minutes>`, compute `end_time = now + <minutes> minutes` as ISO 8601 UTC. Subsequent self-scheduled wake-ups pass `until:<end_time>` to preserve the deadline.
 
 ---

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -40,17 +40,29 @@ gh issue list \
 ```
 
 **Open PRs needing this persona's attention:**
-```bash
-gh pr list \
-  --state open \
-  --json number,title,headRefName,reviewDecision,comments,requestedReviewers \
-  --limit 30 \
-  --jq '[.[] | select(
-      (.headRefName | startswith("feature/developer/")) or
-      (.headRefName | startswith("persona/")) or
-      (.requestedReviewers | length > 0)
-  )] | .[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  comments:\(.comments | length)"'
-```
+
+> If persona is `merge-manager`: fetch ALL open PRs targeting `develop` — the merge-manager reviews every PR, not just ones it owns.
+> ```bash
+> gh pr list \
+>   --state open \
+>   --base develop \
+>   --json number,title,headRefName,reviewDecision,statusCheckRollup,comments \
+>   --limit 30 \
+>   --jq '.[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  ci:\(if (.statusCheckRollup // [] | length) == 0 then "unknown" elif (.statusCheckRollup | all(.[]; .state == "SUCCESS")) then "green" else "failing" end)  comments:\(.comments | length)"'
+> ```
+
+> All other personas: fetch only PRs on their branch or where they are a requested reviewer.
+> ```bash
+> gh pr list \
+>   --state open \
+>   --json number,title,headRefName,reviewDecision,comments,requestedReviewers \
+>   --limit 30 \
+>   --jq '[.[] | select(
+>       (.headRefName | startswith("feature/developer/")) or
+>       (.headRefName | startswith("persona/")) or
+>       (.requestedReviewers | length > 0)
+>   )] | .[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  comments:\(.comments | length)"'
+> ```
 
 Print the results as a brief queue, then proceed to Step 3.
 
@@ -58,7 +70,17 @@ Print the results as a brief queue, then proceed to Step 3.
 
 ## Step 3 — Pick the Highest-Priority Item
 
-Score every item in the queue and pick the highest. In case of a tie, prefer the oldest `updatedAt`.
+**If persona is `merge-manager`**, use this priority order:
+
+| Priority | Condition |
+|---|---|
+| 1 | PR with `ci:green` and `review:APPROVED` — ready to merge now |
+| 2 | PR with `ci:failing` — create or update a blocking issue labeled `persona/<owner>` and `type/bug` |
+| 3 | PR with open `type/security` issues on its branch — comment that it is blocked |
+| 4 | PR with `review:CHANGES_REQUESTED` — already handled by the owning persona; add a comment if stale |
+| 5 | PR with `review:PENDING` and `ci:green` — leave a review |
+
+**All other personas**, score every item and pick the highest. In case of a tie, prefer the oldest `updatedAt`.
 
 | Priority | Condition |
 |---|---|

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ bin/k8s/
 .env.local
 *.local
 test/.env.test.local
+.claude/settings.local.json
 
 # Helm chart lock
 helm/Chart.lock

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Devices are tagged with `cluster_name`, `region`, `health_status`, and `rancher_
 
 ## Quick Start
 
+> **Which branch to use**: `main` contains stable tagged releases only. All bug fixes and in-progress work land in `develop` first. If you are doing usability testing or want the latest fixes, check out `develop` before building:
+> ```bash
+> git checkout develop && git pull origin develop
+> ```
+
 ### Prerequisites
 
 - Go 1.23+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ Uses `github.com/robfig/cron/v3` to compute the next fire time from either `spec
 
 On each scheduled reconcile, `LosantSyncReconciler` executes in order:
 
-1. **Ping** (`lc.Ping`) — verifies the Application API Token via `GET /me`; sets `phase=Degraded` on failure
+1. **Ping** (`lc.Ping`) — verifies the Application API Token via `GET /applications/{id}`; sets `phase=Degraded` on failure
 2. **EnsureClusterDevice** (`lc.EnsureClusterDevice`) — creates or retrieves the Edge Compute device; stores device ID in `Status.ClusterDeviceID`; sets `phase=Degraded` on failure
 3. **EnsureNodeDevice** per node in HealthStore (`lc.EnsureNodeDevice`) — creates or retrieves peripheral devices; sets `phase=Degraded` on first failure
 4. **ReportState cluster** (`gc.ReportState`) — POSTs cluster-level metrics to GEA HTTP endpoint; sets `phase=Degraded` on failure

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -8,6 +8,12 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 ## Prerequisites
 
+> **Which branch to use**: `main` contains stable tagged releases only. All bug fixes and in-progress work land in `develop` first. If you are doing usability testing or want the latest fixes, use `develop`:
+> ```bash
+> git checkout develop && git pull origin develop
+> ```
+> Switch to `main` only when deploying a specific tagged release (e.g., `git checkout v0.1.0`).
+
 ### Step 1 — Decide your run mode
 
 All subsequent steps branch on this decision. Pick one now:
@@ -94,7 +100,7 @@ make install
 2. Create the provisioning secret (requires a Losant Application API Token — see [docs/losant-setup.md](losant-setup.md#step-5-create-an-application-api-token)):
 
    ```bash
-   kubectl create secret generic losant-credentials \
+   kubectl create secret generic losant-provisioning-credentials \
      --from-literal=api-token=<application-api-token> \
      -n losant-system
    ```
@@ -109,7 +115,7 @@ make install
    spec:
      applicationID: "<losant-app-id>"
      provisioningSecretRef:
-       name: losant-credentials
+       name: losant-provisioning-credentials
        namespace: losant-system
      clusterName: "my-k3s-cluster"
      region: "us-east-1"
@@ -150,7 +156,7 @@ Each condition has a `reason` and `message` that identify exactly which step fai
    ```
 2. Verify the provisioning secret exists and contains `api-token`:
    ```bash
-   kubectl get secret losant-credentials -n losant-system -o jsonpath='{.data.api-token}' | base64 -d
+   kubectl get secret losant-provisioning-credentials -n losant-system -o jsonpath='{.data.api-token}' | base64 -d
    ```
 3. Confirm the Losant REST API is reachable from within the cluster:
    ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -12,8 +12,8 @@ Operational procedures for the `losant-device` Kubernetes controller running on 
 
 All subsequent steps branch on this decision. Pick one now:
 
-- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing.
-- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging and production.
+- **`make run`** — controller runs as a local process in your terminal; no Deployment or namespace is created in the cluster. Use this for development and local testing. **Limitation**: cannot reach in-cluster Services (e.g., `losant-gea`), so GEA state reporting always fails. Provisioning steps work, but no metrics will be delivered to Losant.
+- **`make deploy`** — controller runs as an in-cluster pod in the `losant-system` namespace. Use this for staging, production, and any end-to-end testing that includes GEA metric reporting. Uses the published image at `ghcr.io/mak3r/losant-device` — no Docker build required.
 
 ### Step 2 — Install or verify the CRD (all modes)
 
@@ -40,12 +40,17 @@ The controller starts in your terminal and connects to the cluster in `~/.kube/c
 **If you chose `make deploy`:**
 
 ```bash
-# Build and push your image first (set IMG to your registry)
-make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
-
-# Deploy controller + GEA to the losant-system namespace
-make deploy IMG=my-registry/losant-device:v0.x.y
+# Deploy controller + GEA using the published image
+make deploy IMG=ghcr.io/mak3r/losant-device:latest
 ```
+
+> Available image tags: https://github.com/mak3r/losant-device/pkgs/container/losant-device
+>
+> If you have modified the controller source and want to test your changes, build and push your own image first:
+> ```bash
+> make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
+> make deploy IMG=my-registry/losant-device:v0.x.y
+> ```
 
 ### Step 4 — Verify the controller is running
 
@@ -67,15 +72,14 @@ kubectl logs -n losant-system deploy/losant-device-controller-manager -f
 These commands apply only when the controller is already running via `make deploy` and you want to update it.
 
 ```bash
-# Build and push the new image
-make docker-build docker-push IMG=my-registry/losant-device:v0.x.y
-
-# Roll out the new image
-make deploy IMG=my-registry/losant-device:v0.x.y
+# Roll out a new published image
+make deploy IMG=ghcr.io/mak3r/losant-device:<new-tag>
 
 # Update CRDs only (no controller restart needed for CRD additions)
 make install
 ```
+
+> If upgrading from a custom-built image, run `make docker-build docker-push IMG=<your-registry>/losant-device:<new-tag>` first, then `make deploy IMG=<your-registry>/losant-device:<new-tag>`.
 
 ---
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.4"
+const Version = "v0.1.0-alpha.5"

--- a/test/e2e/scheduling_test.go
+++ b/test/e2e/scheduling_test.go
@@ -150,7 +150,7 @@ var _ = Describe("LosantSync scheduling", func() {
 			second := getLosantSync(ctx, name).Status.NextScheduledTime
 			// NextScheduledTime must advance by approximately the interval.
 			// 3s tolerance accounts for reconcile scheduling jitter.
-			Expect(second.Time).To(BeTemporally("~", first.Time.Add(syncInterval), 3*time.Second))
+			Expect(second.Time).To(BeTemporally("~", first.Add(syncInterval), 3*time.Second))
 		})
 
 		// AC-SCHED-06: cron-based NextScheduledTime advances to next cron tick after each sync.
@@ -174,7 +174,7 @@ var _ = Describe("LosantSync scheduling", func() {
 
 			second := getLosantSync(ctx, name).Status.NextScheduledTime
 			// Next tick for "* * * * *" is ~60s from the previous tick; allow 10s tolerance.
-			Expect(second.Time).To(BeTemporally("~", first.Time.Add(time.Minute), 10*time.Second))
+			Expect(second.Time).To(BeTemporally("~", first.Add(time.Minute), 10*time.Second))
 		})
 
 		// AC-SCHED-08/09/10: controller restart behaviour.

--- a/test/testenv/credentials.go
+++ b/test/testenv/credentials.go
@@ -82,7 +82,7 @@ func LoadCredentials() (Credentials, bool) {
 	// If any field is missing, try the local file.
 	if !creds.Complete() {
 		if file, err := os.Open(envFilePath()); err == nil {
-			defer file.Close()
+			defer func() { _ = file.Close() }()
 			overrides := parseEnvFile(file)
 			if creds.ApplicationID == "" {
 				creds.ApplicationID = overrides["LOSANT_APPLICATION_ID"]

--- a/test/testenv/credentials_test.go
+++ b/test/testenv/credentials_test.go
@@ -129,6 +129,6 @@ func writeTempFile(t *testing.T, content string) *os.File {
 	if err != nil {
 		t.Fatalf("writeTempFile open: %v", err)
 	}
-	t.Cleanup(func() { f.Close() })
+	t.Cleanup(func() { _ = f.Close() })
 	return f
 }


### PR DESCRIPTION
## Summary

- Bumps `internal/version/version.go` to `v0.1.0-alpha.5`
- Merges all changes accumulated since `v0.1.0-alpha.2` (see issue #145 for full changelog)
- Fixes critical 403 failures caused by `GET /me` being called instead of `GET /applications/{id}`
- Includes OTel SDK upgrade (CVE fix), Go 1.26.2 toolchain, and CI hardening

## Significant changes included

- `fix(losant)`: replace `GET /me` with `GET /applications/{id}` in Ping — unblocks deploy
- `fix(losant)`: add `gatewayId` to peripheral device creation payload
- `fix(deps)`: upgrade OTel SDK to v1.40.0 — fixes CVE GO-2026-4394
- `chore`: upgrade Go toolchain to 1.26.2 — clears 15 CVEs
- `fix(deploy)`: add `config/manager` and `config/default` so `make deploy` works
- `feat(security)`: add govulncheck and RBAC drift detection to CI

## Test plan

- [x] `make test` passes on `develop` (all packages green, no RBAC drift)
- [ ] CI passes on this PR
- [ ] Merge to `main` and tag `v0.1.0-alpha.5` to trigger release workflow → multi-arch image pushed to `ghcr.io/mak3r/losant-device:v0.1.0-alpha.5`

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)