### PR TITLE
feat(rbac): sync kubebuilder markers for events create/patch and secrets list/watch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,19 +8,23 @@ rules:
   - ""
   resources:
   - events
-  - nodes
-  - persistentvolumeclaims
-  - pods
   verbs:
+  - create
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""
   resources:
+  - nodes
+  - persistentvolumeclaims
+  - pods
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/internal/controller/healthwatcher_controller.go
+++ b/internal/controller/healthwatcher_controller.go
@@ -48,7 +48,7 @@ type HealthWatcherReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
 
 // Reconcile is triggered by changes to any watched resource. It re-computes

--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -52,11 +52,11 @@ type LosantSyncReconciler struct {
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
 
 func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary

- Updates `+kubebuilder:rbac` markers in `losantsync_controller.go` and `healthwatcher_controller.go` to match the security-approved RBAC baseline from `persona/security` commit `ad2e7a6`
- **events** (`create;get;list;patch;watch`) — both controllers; enables leader-election and reconcile status event publishing
- **secrets** (`get;list;watch`) — `losantsync_controller` only; enables the informer reflector cache to start without entering exponential backoff

`make manifests` was run and `git diff --exit-code config/rbac/role.yaml` is clean. The generated role.yaml consolidates nodes/pvcs/pods/secrets into a single `get;list;watch` rule (controller-gen canonical form, functionally identical to the security-authored split).

Closes #144

## Test plan

- [x] `make test` passes (all packages green, including integration tests)
- [x] `make manifests && git diff --exit-code config/rbac/role.yaml` — no drift
- [ ] CI `manifest-drift` job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)