### PR TITLE
fix(rbac): grant events create/patch and secrets list/watch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,15 @@ rules:
   - ""
   resources:
   - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   - persistentvolumeclaims
   - pods
@@ -21,6 +30,8 @@ rules:
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,13 +20,6 @@ rules:
   - nodes
   - persistentvolumeclaims
   - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
## Summary

- Splits `events` into its own RBAC rule and adds `create` and `patch` verbs (required for leader election and reconcile status event publishing)
- Adds `list` and `watch` to `secrets` so the informer cache reflector can start without entering exponential backoff

Security approval for the permission expansion requested in #144.

## Details

**events** — was grouped with nodes/pvcs/pods at `get,list,watch`; now its own rule with `create,get,list,patch,watch`

**secrets** — was `get` only; now `get,list,watch`

## Merge note

Developer PR #151 (`feature/developer/rbac-marker-sync`) updates the `+kubebuilder:rbac` markers to match this baseline. That PR should be merged alongside or after this one so the CI `manifest-drift` check stays green on `develop`.

Closes #144
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)