### PR TITLE
docs: handoff rules, CLAUDE.md updates, runbook fixes, project-manager-guide, watch-work enforcement

### DIFF
--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -146,6 +146,17 @@ For the selected item:
    - If you modified manifests: `make manifests && git diff --exit-code config/rbac/role.yaml`
    - Docs/YAML changes: no build step required
 
+4b. **Handoff check** — before committing, ask: does completing this work make another persona's task available that was not visible before? Common examples:
+   - Security approves RBAC change → developer can now add the marker
+   - Developer completes implementation → test-engineer can now write tests
+   - PR is ready and tests pass → merge-manager can review
+
+   If yes, execute the handoff as part of this work item (not as a follow-on):
+   - Re-label the current issue to `persona/<next>` and comment with what was done and exactly what the next persona must do, OR
+   - Create a new `persona/<next>` issue with explicit instructions
+
+   **The handoff action is a required deliverable.** Do not close or move past this item until handoff is complete.
+
 5. **Commit** using conventional commit style:
    ```
    <type>(<scope>): <description>

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -188,7 +188,7 @@ After completing an item (or finding an empty queue):
 **Watch mode:**
 - Is `now < end_time`?
   - **Yes and work was just completed**: immediately return to Step 2 to check for more work.
-  - **Yes and queue was empty**: call `ScheduleWakeup` with `delaySeconds: 270`, `reason: "Polling for new work for <persona>"`, `prompt: "/watch-work <persona> until:<end_time_iso>"`
+  - **Yes and queue was empty**: call `ScheduleWakeup` with `delaySeconds: 270`, `reason: "Polling for new work for <persona>"`, `prompt: "Resume watch-work: you are the <persona> persona. Continue from Step 2 — scan for open issues and PRs, pick the highest-priority item, do the work, then loop. Session ends at <end_time_iso>. Do not use slash commands; invoke the watch-work skill directly via the Skill tool with skill name 'watch-work' and args '<persona> until:<end_time_iso>'."`
   - **No**: print `Session complete for <persona>. Items completed this session: <N>.` and stop.
 
 ---

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -146,17 +146,6 @@ For the selected item:
    - If you modified manifests: `make manifests && git diff --exit-code config/rbac/role.yaml`
    - Docs/YAML changes: no build step required
 
-4b. **Handoff check** — before committing, ask: does completing this work make another persona's task available that was not visible before? Common examples:
-   - Security approves RBAC change → developer can now add the marker
-   - Developer completes implementation → test-engineer can now write tests
-   - PR is ready and tests pass → merge-manager can review
-
-   If yes, execute the handoff as part of this work item (not as a follow-on):
-   - Re-label the current issue to `persona/<next>` and comment with what was done and exactly what the next persona must do, OR
-   - Create a new `persona/<next>` issue with explicit instructions
-
-   **The handoff action is a required deliverable.** Do not close or move past this item until handoff is complete.
-
 5. **Commit** using conventional commit style:
    ```
    <type>(<scope>): <description>

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -170,7 +170,12 @@ For the selected item:
 
    **Do not comment with a commit SHA or close the issue until the handoff action is complete.**
 
-6. **Update the issue/PR:** comment with a one-line summary of what was done and the verified commit SHA.
+6. **Update the issue/PR:** comment must include all of the following — do not summarize or paraphrase, paste the actual output:
+   - Output of `git log --oneline -1` (proves the commit exists with its real message and SHA)
+   - PR URL (from `gh pr create` output or `gh pr view --json url --jq '.url'`)
+   - For any file-level fix: output of a `grep` or `head` command confirming the change is present in the file (e.g. `grep '^FROM golang:' Dockerfile`)
+
+   Fabricated or assumed output will be caught by the merge-manager. If you cannot produce real output, the commit did not happen — do not close the issue.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,30 @@ Runs automatically via `.github/workflows/docs-agent.yml` on every merged PR. It
 
 To manually trigger a docs pass: use the `/docs-refresh` Claude Code skill.
 
+## Handoff Rules
+
+**A persona's work is not complete until the next persona in the chain can find and act on it.**
+
+Finishing your own file edits and committing is necessary but not sufficient. If your work creates a dependency for another persona, you must hand off before closing the issue.
+
+### General rule (applies to all personas)
+
+After completing work that unblocks another persona, choose one of:
+
+1. **Same issue, next persona**: Remove your `persona/<name>` label from the issue, add `persona/<next>` label, and comment with what was done and exactly what the next persona must do.
+2. **New issue for distinct task**: Create a new issue labeled `persona/<next>`, `phase/<n>`, and `type/<task|bug|security>` with explicit instructions, then close your issue.
+
+Without a handoff, the queue-based `watch-work` model breaks — agents only pick up issues labeled for their persona.
+
+### Security → Developer handoff (example)
+
+When the security persona approves an RBAC change:
+1. Update `config/rbac/role.yaml` and commit to `persona/security`
+2. Comment on the issue with the approved verbs and the exact `// +kubebuilder:rbac` markers the developer must add
+3. **Re-label** the issue from `persona/security` to `persona/developer` — or open a new `persona/developer` issue — so the developer's `watch-work` queue picks it up
+
+Step 3 is mandatory. Without it, the developer never sees the work.
+
 ## Standard Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,14 +96,33 @@ After completing work that unblocks another persona, choose one of:
 
 Without a handoff, the queue-based `watch-work` model breaks — agents only pick up issues labeled for their persona.
 
+### Re-label vs. new issue decision rule
+
+**Re-label** when the next persona is doing a second stage of the same change (the existing issue title still describes the work). **Open a new issue** when the next persona's work is distinct or additive (the existing title would not describe it).
+
+Decision shortcut: "Can the existing issue title describe what the next persona must do?" If yes → re-label. If no → new issue.
+
+Examples:
+- Security approves RBAC change → developer adds marker: **re-label** (same change, two stages)
+- Merge-manager merges PR → docs updates README: **new issue** (different scope)
+
 ### Security → Developer handoff (example)
 
 When the security persona approves an RBAC change:
 1. Update `config/rbac/role.yaml` and commit to `persona/security`
 2. Comment on the issue with the approved verbs and the exact `// +kubebuilder:rbac` markers the developer must add
-3. **Re-label** the issue from `persona/security` to `persona/developer` — or open a new `persona/developer` issue — so the developer's `watch-work` queue picks it up
+3. **Re-label** the issue from `persona/security` to `persona/developer` — so the developer's `watch-work` queue picks it up
 
 Step 3 is mandatory. Without it, the developer never sees the work.
+
+## Definition of Done
+
+Before closing any issue or PR, every persona must verify all of the following:
+
+1. Changes are within this persona's designated file scope (from the table in **Personas and Branch Ownership**).
+2. Work is committed; where applicable, tests pass (`make test` for Go changes; `make manifests && git diff --exit-code config/rbac/role.yaml` for manifest changes).
+3. The issue or PR has a one-line summary comment linking the commit SHA.
+4. Handoff is complete — if this work unblocks another persona, that persona's queue has been updated (re-labeled issue or new issue with explicit instructions).
 
 ## Standard Commands
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,10 +224,11 @@ Single device selected by device ID context variable. Time-series CPU%, memory%,
 The controller ClusterRole requires:
 
 ```yaml
-- get/list/watch: nodes, pods, persistentvolumeclaims, events, deployments
-- get/update/patch: losantsyncs, losantsyncs/status, losantsyncs/finalizers
-- get: secrets (provisioning credentials only)
-- get/list/watch/create/update/patch: leases (leader election)
+- create/get/list/patch/watch: events
+- get/list/watch: nodes, pods, persistentvolumeclaims, secrets, deployments
+- get/patch/update/list/watch: losantsyncs
+- get/patch/update: losantsyncs/status
+- create/get/list/patch/update/watch: leases (leader election)
 ```
 
 The GEA pod has its own ServiceAccount with no Kubernetes API permissions — it only communicates outbound to `broker.losant.com`.

--- a/docs/project-manager-guide.md
+++ b/docs/project-manager-guide.md
@@ -1,0 +1,159 @@
+# Project Manager Guide
+
+This guide covers how to set up and operate the multi-persona Claude agent system for `losant-device`. It assumes familiarity with git and the terminal but not with git worktrees or the Claude Code multi-persona pattern.
+
+---
+
+## Workspace Layout
+
+The agent workspace lives at `~/projects/losant-device-agents/` as a separate git clone from the planning/organizing repo (`~/projects/losant-device`). Most personas use git worktrees so each Claude Code session is automatically isolated to the correct branch.
+
+The `developer` and `test-engineer` personas use **standalone clones** instead of worktrees, because their branches change dynamically and the agents manage their own branch lifecycle autonomously.
+
+```
+~/projects/losant-device-agents/
+├── main/            ← worktree, develop branch  (merge-manager runs here)
+├── security/        ← worktree, persona/security
+├── qa/              ← worktree, persona/qa
+├── gitops/          ← worktree, persona/gitops-manager
+├── docs/            ← worktree, persona/docs
+├── product/         ← worktree, persona/product-designer
+├── developer/       ← standalone clone, starts on develop
+└── test-engineer/   ← standalone clone, starts on develop
+```
+
+---
+
+## Initial Setup
+
+Run these steps once when creating the workspace for the first time.
+
+### 1. Create the root clone and worktrees
+
+```bash
+# Create the root clone (used as the worktree source)
+git clone git@github.com:mak3r/losant-device.git ~/projects/losant-device-agents/main
+cd ~/projects/losant-device-agents/main
+git checkout develop
+
+# Create worktrees for static personas
+git worktree add ../security  persona/security
+git worktree add ../qa        persona/qa
+git worktree add ../gitops    persona/gitops-manager
+git worktree add ../docs      persona/docs
+git worktree add ../product   persona/product-designer
+```
+
+### 2. Create standalone clones for developer and test-engineer
+
+```bash
+cd ~/projects/losant-device-agents
+git clone git@github.com:mak3r/losant-device.git developer
+git -C developer checkout develop
+
+git clone git@github.com:mak3r/losant-device.git test-engineer
+git -C test-engineer checkout develop
+```
+
+### 3. Propagate settings
+
+If you have a `settings.local.json` (API key, permissions), symlink it into every directory so all personas share one config:
+
+```bash
+for dir in main security qa gitops docs product developer test-engineer; do
+  ln -s ~/projects/losant-device-agents/main/.claude/settings.local.json \
+        ~/projects/losant-device-agents/$dir/.claude/settings.local.json
+done
+```
+
+### 4. Initialize each workspace
+
+Open a terminal in each directory, launch `claude`, and run `/persona-setup`. This downloads Go modules and installs the required toolchain binaries (`controller-gen`, `kustomize`, `envtest`, `golangci-lint`) into `./bin/`.
+
+---
+
+## Starting a Persona Session
+
+Open a terminal in the persona's directory, launch `claude`, and run `/watch-work <persona>`. That is all. The agent will scan for open issues and PRs, pick the highest-priority item, and work through the queue until the session ends or no work remains.
+
+To run a session for a fixed duration (e.g. 60 minutes):
+
+```
+/watch-work <persona> 60
+```
+
+| Directory        | Command                              |
+|------------------|--------------------------------------|
+| `main/`          | `/watch-work merge-manager`          |
+| `security/`      | `/watch-work security`               |
+| `qa/`            | `/watch-work qa`                     |
+| `gitops/`        | `/watch-work gitops-manager`         |
+| `docs/`          | `/watch-work docs`                   |
+| `product/`       | `/watch-work product-designer`       |
+| `developer/`     | `/watch-work developer`              |
+| `test-engineer/` | `/watch-work test-engineer`          |
+
+You never need to create or switch branches for `developer` or `test-engineer` — the agents handle that autonomously (see below).
+
+---
+
+## Developer Feature Lifecycle (Agent-Managed)
+
+The developer agent starts from the `develop` branch each loop iteration:
+
+1. Scans for open issues labeled `persona/developer`
+2. Picks the highest-priority issue
+3. Derives a branch slug from the issue title and number (e.g. `feature/developer/123-add-node-metrics`)
+4. Runs `git checkout -b feature/developer/<slug> origin/develop`
+5. Implements the feature, runs `make test`, commits, and opens a PR
+6. After the PR is merged: `git checkout develop && git pull origin develop && git branch -d feature/developer/<slug>`
+7. Loops back to issue selection
+
+No human action is needed. Do not create worktrees or branches for the developer manually.
+
+---
+
+## Test-Engineer Pairing (Agent-Managed)
+
+The test-engineer agent also starts from `develop` each loop iteration and selects its target branch based on available work:
+
+1. Scans for open `feature/developer/*` PRs and issues labeled `persona/test-engineer`
+2. If there are open developer feature PRs needing tests: checks out `feature/developer/<name>` and writes `*_test.go` files alongside the implementation
+3. If there is test-infrastructure work (issues on `persona/test-engineer`): checks out `persona/test-engineer` and works there
+4. If both exist, feature work takes priority (shipping blockers come first)
+5. After completing work: pushes, then returns to `develop`
+
+No human action is needed. The agent selects the right branch automatically.
+
+---
+
+## Merge Manager
+
+The merge manager runs from `main/` (develop branch). It does not commit code — it only uses the `gh` CLI to review PRs, create blocking issues, and merge approved work.
+
+On each loop it:
+1. Checks all open PRs targeting `develop`
+2. Merges PRs that are CI-green and approved
+3. Creates blocking issues for failing CI or open security concerns
+4. Leaves reviews on PRs that are pending
+
+No dedicated branch or worktree is needed — `main/` on `develop` is sufficient.
+
+---
+
+## Organizing Work
+
+Use `~/projects/losant-device` (the original planning clone) to:
+
+- Review architecture documents in `docs/` and `.claude/plans/`
+- Create and triage GitHub issues
+- Review PRs and check CI status
+- Direct personas by assigning labels and milestones
+
+Agents in `~/projects/losant-device-agents/` do the implementation. The two repos share the same GitHub remote, so issues and PRs are visible from both.
+
+---
+
+## Memory
+
+Each directory gets its own Claude memory namespace keyed to its filesystem path. Memories accumulate over sessions and help the agent recall project context, preferences, and prior decisions. No action is needed — memory persists automatically.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -47,10 +47,10 @@ The controller starts in your terminal and connects to the cluster in `~/.kube/c
 
 ```bash
 # Deploy controller + GEA using the published image
-make deploy IMG=ghcr.io/mak3r/losant-device:v0.1.0-alpha.2
+make deploy IMG=ghcr.io/mak3r/losant-device:v0.1.0-alpha.4
 ```
 
-> Current release: `v0.1.0-alpha.2`. All available tags: https://github.com/mak3r/losant-device/pkgs/container/losant-device
+> Current release: `v0.1.0-alpha.4`. All available tags: https://github.com/mak3r/losant-device/pkgs/container/losant-device
 >
 > If you have modified the controller source and want to test your changes, build and push your own image first:
 > ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -47,10 +47,10 @@ The controller starts in your terminal and connects to the cluster in `~/.kube/c
 
 ```bash
 # Deploy controller + GEA using the published image
-make deploy IMG=ghcr.io/mak3r/losant-device:latest
+make deploy IMG=ghcr.io/mak3r/losant-device:v0.1.0-alpha.2
 ```
 
-> Available image tags: https://github.com/mak3r/losant-device/pkgs/container/losant-device
+> Current release: `v0.1.0-alpha.2`. All available tags: https://github.com/mak3r/losant-device/pkgs/container/losant-device
 >
 > If you have modified the controller source and want to test your changes, build and push your own image first:
 > ```bash


### PR DESCRIPTION
Batch of docs work accumulated since last merge:
- Handoff Rules section in CLAUDE.md (closes #146)
- Definition of Done and re-label rule in CLAUDE.md (closes #149)
- project-manager-guide.md for multi-persona worktree setup (closes #141)
- Autonomous branch lifecycle for developer/test-engineer in watch-work (closes #142)
- Runbook: replace :latest with versioned tag (closes #143)
- watch-work: handoff checkpoint (closes #150)
- watch-work: SHA verification, PR gate, handoff enforcement (closes #153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)