### PR TITLE
fix(e2e): update provisioning secret to use api-token key

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -93,8 +93,7 @@ func ensureTestNamespaceAndSecret(ctx context.Context) {
 			Namespace: e2eNamespace,
 		},
 		StringData: map[string]string{
-			"accessKey":    "e2e-placeholder-key",
-			"accessSecret": "e2e-placeholder-secret",
+			"api-token": "e2e-placeholder-token",
 		},
 	}
 	err = k8sClient.Create(ctx, secret)


### PR DESCRIPTION
## Summary

- Updates the e2e provisioning secret to use the correct `api-token` key instead of the previous key name
- Fixes the e2e test setup that was failing due to the secret key mismatch

## Test plan

- [ ] E2E tests pass with the corrected secret key (`make e2e` with a valid kubeconfig)
- [ ] No unit/integration test regressions (`make test`)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)