### PR TITLE
test(gea): cover ReportState marshal and network error paths (closes #170)

### DIFF
--- a/internal/gea/client_test.go
+++ b/internal/gea/client_test.go
@@ -209,3 +209,40 @@ func TestReportState_Success_ReturnsNil(t *testing.T) {
 		t.Fatalf("ReportState: unexpected error: %v", err)
 	}
 }
+
+// TestReportState_MarshalError verifies that an un-serializable attribute value
+// (channel type) causes ReportState to return a marshal error without making an
+// HTTP call.
+func TestReportState_MarshalError(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	payload := StatePayload{
+		DeviceID:   "dev-bad",
+		Attributes: map[string]interface{}{"ch": make(chan int)}, // channels are not JSON-serializable
+	}
+	if err := newTestHTTPClient(srv.URL).ReportState(context.Background(), payload); err == nil {
+		t.Fatal("expected marshal error, got nil")
+	}
+	if callCount != 0 {
+		t.Errorf("expected no HTTP calls on marshal error, got %d", callCount)
+	}
+}
+
+// TestReportState_NetworkError verifies that a connection failure (server closed
+// before the call) surfaces as a recognisable error.
+func TestReportState_NetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close() // close immediately so the POST will fail
+
+	payload := StatePayload{DeviceID: "dev-net", Attributes: map[string]interface{}{"x": 1}}
+	if err := newTestHTTPClient(srv.URL).ReportState(context.Background(), payload); err == nil {
+		t.Fatal("expected network error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/gea` coverage: **93.3% → 96.7%**
- `ReportState` coverage: **82.4% → 94.1%**

## Tests added

| Test | Branch covered |
|---|---|
| `TestReportState_MarshalError` | `json.Marshal` fails on un-serializable attribute (channel type); error returned without HTTP call |
| `TestReportState_NetworkError` | GEA server closed before call; connection error surfaces correctly |

## Test plan

- [x] `make test` passes — all packages green
- [x] `internal/gea` coverage confirmed at 96.7% via `go tool cover -func`

🤖 Generated with [Claude Code](https://claude.com/claude-code)