### PR TITLE
test(monitor): cover clamp/requestPct/isPodReady edge branches to 100%

### DIFF
--- a/internal/monitor/health_score_test.go
+++ b/internal/monitor/health_score_test.go
@@ -141,6 +141,12 @@ func TestComputeClusterHealthScore_NoNodes(t *testing.T) {
 	}
 }
 
+func TestClamp_AboveMax(t *testing.T) {
+	if got := clamp(150, 0, 100); got != 100 {
+		t.Errorf("clamp(150, 0, 100): got %d, want 100", got)
+	}
+}
+
 func TestComputeClusterHealthScore_ClampedToZero(t *testing.T) {
 	cluster := ClusterHealth{
 		CrashLoopPods:  50,

--- a/internal/monitor/node_collector_test.go
+++ b/internal/monitor/node_collector_test.go
@@ -117,6 +117,15 @@ func TestCollectNodeHealth_ZeroCapacity(t *testing.T) {
 	}
 }
 
+func TestRequestPct_AllocatableExceedsCapacity(t *testing.T) {
+	// When allocatable > capacity the pct is negative; clamp returns 0.
+	alloc := resource.MustParse("1200m")
+	cap := resource.MustParse("1000m")
+	if got := requestPct(alloc, cap); got != 0 {
+		t.Errorf("requestPct when alloc > cap: got %f, want 0", got)
+	}
+}
+
 func TestCollectNodeHealth_ResourcePct(t *testing.T) {
 	// allocatable=500m out of 1000m means 50% requested
 	node := makeNode("n5", readyConditions(), "500m", "1000m", "512Mi", "1024Mi")

--- a/internal/monitor/pod_collector_test.go
+++ b/internal/monitor/pod_collector_test.go
@@ -102,6 +102,13 @@ func TestCollectPodCounts_Empty(t *testing.T) {
 	}
 }
 
+func TestIsPodReady_NoConditions(t *testing.T) {
+	pod := &corev1.Pod{} // no PodReady condition — falls through to return false
+	if isPodReady(pod) {
+		t.Error("isPodReady: expected false for pod with no conditions")
+	}
+}
+
 func TestCollectPodCounts_CrashLoopNotCountedAsNotReady(t *testing.T) {
 	// A CrashLoopBackOff pod is pending/waiting — not in Running phase.
 	// NotReady counter only increments for Running pods that are not Ready.


### PR DESCRIPTION
## Summary

- Add `TestClamp_AboveMax` in `health_score_test.go` to cover the `v > max → return max` branch of `clamp`
- Add `TestRequestPct_AllocatableExceedsCapacity` in `node_collector_test.go` to cover the `pct < 0 → pct = 0` guard in `requestPct`
- Add `TestIsPodReady_NoConditions` in `pod_collector_test.go` to cover the `return false` fallthrough in `isPodReady` when no PodReady condition is present

`internal/monitor` now reports **100% statement coverage**.

Closes #172

## Test plan

- [x] `make test` passes with `internal/monitor` at 100% coverage
- [x] No non-test Go files modified