### PR TITLE
fix(ci): add Dockerfile Go version check + fix builder base image to golang:1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,22 @@ jobs:
       - name: Build
         run: go build ./...
 
+  dockerfile-go-version:
+    name: Dockerfile Go version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Dockerfile builder matches go.mod
+        run: |
+          GOMOD_VER=$(grep '^go ' go.mod | awk '{print $2}')
+          DOCKERFILE_VER=$(grep '^FROM golang:' Dockerfile | sed 's/FROM golang:\([^ ]*\).*/\1/')
+          echo "go.mod requires: $GOMOD_VER"
+          echo "Dockerfile uses: $DOCKERFILE_VER"
+          if [ "$GOMOD_VER" != "$DOCKERFILE_VER" ]; then
+            echo "ERROR: Dockerfile golang version ($DOCKERFILE_VER) does not match go.mod ($GOMOD_VER)"
+            exit 1
+          fi
+
   helm-lint:
     name: Helm Lint
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23 AS builder
+FROM golang:1.26.2 AS builder
 ARG TARGETOS TARGETARCH
 WORKDIR /workspace
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- Bumps `Dockerfile` builder base image from `golang:1.23` to `golang:1.26.2` to match `go.mod`
- Adds `dockerfile-go-version` CI job to `.github/workflows/ci.yml` that fails if the Dockerfile builder image drifts from `go.mod` in future

## Root cause

Release workflow failed three times (`v0.1.0-alpha.3–5`) because the runner-provided Go masked the stale Dockerfile image until release builds used the image directly.

## Test plan

- [ ] `grep '^FROM golang:' Dockerfile` returns `FROM golang:1.26.2 AS builder`
- [ ] `dockerfile-go-version` CI job passes green on this PR
- [ ] Intentionally mismatching versions causes the job to exit 1

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)