### PR TITLE
feat(ci): auto-close issues when PR merges to develop

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,25 @@
+name: Close Linked Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | while read num; do
+            echo "Closing issue #$num"
+            gh issue close "$num" --repo "$REPO" --comment "Closed automatically: fixed by PR #${{ github.event.pull_request.number }} merged to develop." || true
+          done

--- a/config/gea/deployment.yaml
+++ b/config/gea/deployment.yaml
@@ -50,15 +50,13 @@ spec:
             - name: gea-data
               mountPath: /data
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/mak3r/losant-device
-  newTag: latest
+  newTag: v0.1.0-alpha.6

--- a/helm/templates/gea-deployment.yaml
+++ b/helm/templates/gea-deployment.yaml
@@ -45,9 +45,13 @@ spec:
           volumeMounts:
             - name: gea-data
               mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.gea.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.gea.service.port }}
             initialDelaySeconds: 30
             periodSeconds: 30


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/close-issues.yml` that fires on every PR merge to `develop`
- Extracts `Closes/Fixes/Resolves #N` references from the PR body and closes each linked issue automatically with a comment
- Prevents issue accumulation between `develop` merges and the eventual release PR to `main`
- Pins `config/manager/kustomization.yaml` image tag to `v0.1.0-alpha.6` (was floating `:latest`)
- Switches GEA liveness and readiness probes from `httpGet /` to `tcpSocket` (fixes #182) — the Losant edge agent only handles `POST /state`, so HTTP GET probes always timed out

## Test plan

- [ ] `grep -r 'close-issues' .github/workflows/` returns the new file
- [ ] Workflow appears in CI checks on this PR
- [ ] Merge a test PR with `Closes #X` in body; issue closes automatically
- [ ] `kubectl describe pod -n losant-system <gea-pod>` shows readiness/liveness probes as tcpSocket after deploy
- [ ] GEA pod stabilizes without repeated restarts on a fresh cluster

Closes #176
Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)