### PR TITLE
fix(controller): add GenerationChangedPredicate to prevent status-update re-reconcile

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -29,8 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
 	"github.com/mak3r/losant-device/internal/gea"
@@ -206,7 +208,8 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // SetupWithManager registers the controller with the manager.
 func (r *LosantSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&losantv1alpha1.LosantSync{}).
+		For(&losantv1alpha1.LosantSync{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }
 


### PR DESCRIPTION
## Summary
- Adds `GenerationChangedPredicate` to the `LosantSync` watch in `SetupWithManager`
- Status subresource updates no longer re-enqueue the object, so `requeueOnDegraded` backoff is respected
- Only spec changes (generation bumps) trigger a reconcile

## Test plan
- [ ] `make test` passes (all existing tests green, 89.3% controller coverage maintained)
- [ ] When GEA is unreachable, verify logs show ~1 minute gap between retry attempts instead of immediate re-reconcile

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)