### PR TITLE
fix(controller): downgrade GEA unreachable log from Error to Info

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -162,7 +162,7 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		DeviceID:   clusterDeviceID,
 		Attributes: clusterAttributes(clusterSnapshot),
 	}); err != nil {
-		logger.Error(err, "failed to report cluster state to GEA")
+		logger.Info("GEA unreachable, will retry", "error", err.Error())
 		return r.setDegraded(ctx, &ls, "GEAReachable", "GEAUnreachable", err.Error())
 	}
 	setCondition(&ls, "GEAReachable", metav1.ConditionTrue, "Reachable", "GEA accepted cluster state")


### PR DESCRIPTION
## Summary
- Replaces `logger.Error(err, "failed to report cluster state to GEA")` with `logger.Info("GEA unreachable, will retry", "error", err.Error())`
- GEA unavailability at edge locations is an expected transient state, not a code error — `logger.Error` was emitting full stack traces every ~1 min
- Degraded condition, status update, and `requeueOnDegraded` backoff are all unchanged

## Test plan
- [ ] `make test` passes (all existing tests green)
- [ ] Confirm no stack traces in logs when GEA is unreachable; only a single `Info`-level line per reconcile attempt

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)