### PR TITLE
feat(api): add GEA printer column to surface GEAReachable condition in kubectl get

### DIFF
--- a/api/v1alpha1/losantsync_types.go
+++ b/api/v1alpha1/losantsync_types.go
@@ -141,6 +141,7 @@ type LosantSyncStatus struct {
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.clusterName`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="GEA",type=string,JSONPath=`.status.conditions[?(@.type=="GEAReachable")].status`
 // +kubebuilder:printcolumn:name="Last Sync",type=date,JSONPath=`.status.lastSyncTime`
 // +kubebuilder:printcolumn:name="Next Sync",type=date,JSONPath=`.status.nextScheduledTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`


### PR DESCRIPTION
## Summary
- Adds a `GEA` column to the `LosantSync` CRD printer columns, showing `True`/`False` for the `GEAReachable` condition
- Operators can now detect GEA connectivity issues at a glance via `kubectl get losantsync` without grepping logs
- The `GEAReachable` condition was already being set/cleared by the controller on each reconcile cycle — this change makes it visible

## Example output
```
NAME      CLUSTER   PHASE    GEA    LAST SYNC   NEXT SYNC   AGE
my-sync   prod-k3s  Active   True   2m          3m          5d
my-sync   prod-k3s  Degraded False  10m         1m          5d
```

## Test plan
- [ ] `make test` passes
- [ ] `kubectl get losantsync` shows the GEA column with `True` when healthy, `False` when GEA is unreachable

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)