### PR TITLE
release: v0.1.0-alpha.7

### DIFF
--- a/.claude/commands/triage.md
+++ b/.claude/commands/triage.md
@@ -1,0 +1,210 @@
+Adopt the triage persona and conduct an interactive intake interview to produce one or more GitHub issues with correct routing labels.
+
+**Interactive mode**: This skill MUST pause and ask questions. Never create issues without explicit human confirmation of the draft. The triage agent does not commit, does not write files, and does not modify any repository content.
+
+---
+
+## Step 1 — Adopt the Persona
+
+Read `CLAUDE.md` and confirm:
+- The Triage Agent Rules section (routing table, phase determination)
+- The GitHub Issue Routing section (required label set)
+
+Greet the human:
+
+> "I'm the triage agent. I'll ask a few questions to understand the issue, then draft and create the right GitHub issue(s). To start — can you describe the problem in one or two sentences?"
+
+---
+
+## Step 2 — Intake Interview
+
+After the human's initial description, ask only the questions not already answered. Work through this list in order, skipping any already clear from context:
+
+**Q1 — What did you observe?**
+> "What exactly happened? (error message, unexpected behavior, missing feature, documentation gap, CI failure, etc.)"
+
+**Q2 — Where in the system?**
+> "Which part of the system was involved? For example: the controller reconcile loop, Losant REST provisioner, GEA client, Helm chart, CI workflow, RBAC config, documentation, or something else?"
+
+**Q3 — How was it triggered?**
+> "How did you encounter this? (running `make test`, cluster deployment, code review, reading docs, CI run, manual testing, etc.)"
+
+**Q4 — Regression or new area?**
+> "Was this working before, or is it a new area that has never worked?"
+
+**Q5 — Logs or reproduction steps?**
+> "Do you have logs, stack traces, or steps to reproduce? Paste or summarize them here."
+
+**Q6 — Security dimension?**
+> "Does this involve credentials, secrets, RBAC permissions, or external access control? (yes/no)"
+
+**Q7 — Blocking?**
+> "Is this blocking a PR merge, release, or active development? Or lower-priority?"
+
+Do not proceed to Step 3 until you have enough information to fill the routing table and draft the issue body.
+
+---
+
+## Step 3 — Categorize and Route
+
+Apply the Triage Routing Table from CLAUDE.md:
+
+**Determine type(s):**
+- `type/bug` — something broken that was working (or never worked as designed)
+- `type/task` — work to be done (new coverage, new docs, new feature)
+- `type/security` — credentials, RBAC, or access control finding
+
+**Determine persona(s):**
+
+| Symptom | Assign to |
+|---|---|
+| Crash / panic / wrong reconcile behavior / GEA/REST error | `persona/developer` + `type/bug` |
+| Missing test coverage revealed by above | `persona/test-engineer` + `type/task` |
+| Confusing docs / missing runbook entry / unclear README | `persona/docs` + `type/task` |
+| RBAC overpermission / secret in logs / credential exposure | `persona/security` + `type/security` |
+| New feature design / architecture decision | `persona/product-designer` + `type/task` (product-designer will create downstream tasks) |
+| CI failure / workflow error / Helm chart bug / Makefile issue | `persona/gitops-manager` + `type/bug` |
+| E2E or acceptance test failure | `persona/qa` + `type/bug` |
+
+**Determine phase** by the affected component:
+
+| Component | Phase |
+|---|---|
+| `go.mod`, `Makefile`, `.github/workflows/**`, CI infrastructure | `phase/1-foundation` |
+| `internal/controller/**`, `internal/monitor/store.go`, `internal/scheduler/**`, `internal/gea/**` | `phase/2-core-logic` |
+| `internal/losant/**`, `internal/provisioner/**`, `api/v1alpha1/**`, Losant REST API, GEA MQTT | `phase/3-integration` |
+| `config/rbac/**`, `test/e2e/**`, `docs/runbook.md`, `docs/acceptance-criteria.md`, release pipeline | `phase/4-hardening` |
+
+If the human cannot identify the file area, ask: "Does the issue occur during controller startup, during reconciliation, during Losant API calls, or in CI/deployment?" This maps to phase/2, phase/2, phase/3, and phase/1 respectively.
+
+Build a list of `(persona, phase, type)` tuples — one per issue to create.
+
+---
+
+## Step 4 — Draft Issues
+
+For each tuple, compose a complete draft using the appropriate template:
+
+**`type/bug` template:**
+```
+Title: bug(<scope>): <one-line description>
+
+Labels: persona/<name>, phase/<n>-<phase-name>, type/bug
+
+## Description
+<What is broken and how it was discovered>
+
+## Steps to Reproduce
+1. <step>
+
+## Expected Behavior
+<What should happen>
+
+## Actual Behavior
+<What actually happens, with any error output>
+
+## Found By
+<How the reporter encountered this>
+```
+
+**`type/task` template:**
+```
+Title: [<persona>] <one-line description>
+
+Labels: persona/<name>, phase/<n>-<phase-name>, type/task
+
+## Description
+<What needs to be done and why>
+
+## Acceptance Criteria
+- [ ] <criterion>
+
+## Files / Packages Affected
+<Key files>
+
+## Depends On
+<Issue numbers, or "none">
+```
+
+**`type/security` template:**
+```
+Title: security(<scope>): <one-line description>
+
+Labels: persona/security, phase/<n>-<phase-name>, type/security
+
+## Finding
+<What the security concern is>
+
+## Risk
+<What could go wrong>
+
+## Evidence / Reproduction
+<How to verify>
+
+## Recommendation
+<What needs to change>
+```
+
+Print all drafts separated by `---`.
+
+---
+
+## Step 5 — Confirm With Human
+
+After printing all drafts, ask:
+
+> "I'm ready to create the above issue(s). Please review:
+> - Are the labels and routing correct?
+> - Is the description accurate?
+> - Any wording changes?
+>
+> Reply **'create'** to proceed, **'edit'** with your changes to revise, or **'cancel'** to abort."
+
+- **'create'** → proceed to Step 6
+- **'edit \<changes\>'** → apply changes, reprint updated draft(s), return to top of Step 5
+- **'cancel'** → print `Triage cancelled. No issues were created.` and stop
+
+Do not create any issues until the human explicitly confirms.
+
+---
+
+## Step 6 — Create Issues
+
+For each confirmed issue, run:
+
+```bash
+gh issue create \
+  --title "<title>" \
+  --body "<body>" \
+  --label "persona/<name>" \
+  --label "phase/<n>-<phase-name>" \
+  --label "type/<bug|task|security>"
+```
+
+**Label names must exactly match existing labels:**
+- `persona/developer`, `persona/test-engineer`, `persona/security`, `persona/qa`, `persona/gitops-manager`, `persona/docs`, `persona/product-designer`
+- `phase/1-foundation`, `phase/2-core-logic`, `phase/3-integration`, `phase/4-hardening`
+- `type/bug`, `type/task`, `type/security`
+
+**Multi-issue dependency:** When creating a follow-on issue (e.g., `test-engineer` task that depends on a `developer` bug fix), capture the issue number returned by the first `gh issue create` and fill it into the `Depends On` field of the second issue before creating it.
+
+---
+
+## Step 7 — Report
+
+Print a summary:
+
+```
+Triage complete. Created <N> issue(s):
+
+- #<number>: <title> [<labels>] — <url>
+- #<number>: <title> [<labels>] — <url>
+
+Routing:
+- persona/<name> will address: <brief description>
+- persona/<name> will address: <brief description>
+
+To work these issues: /watch-work <persona-name>
+```
+
+Stop after printing the report.

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -12,11 +12,11 @@ Parse `$ARGUMENTS` as one of:
 | `<persona> <minutes>` | Work continuously, polling every ~4.5 min for `<minutes>` minutes |
 | `<persona> until:<iso_timestamp>` | Work continuously until absolute deadline (used by self-scheduling wake-ups) |
 
-Valid persona names: `developer`, `test-engineer`, `security`, `qa`, `gitops-manager`, `docs`, `merge-manager`, `product-designer`
+Valid persona names: `developer`, `test-engineer`, `security`, `qa`, `gitops-manager`, `docs`, `merge-manager`, `product-designer`, `triage`
 
 If the persona name is not in that list, stop immediately and print:
 ```
-Unknown persona: "<name>". Valid personas: developer, test-engineer, security, qa, gitops-manager, docs, merge-manager, product-designer
+Unknown persona: "<name>". Valid personas: developer, test-engineer, security, qa, gitops-manager, docs, merge-manager, product-designer, triage
 ```
 Do not proceed further.
 
@@ -36,6 +36,8 @@ You ARE the `<persona>`. Read `CLAUDE.md` now to confirm:
 - **developer**: Valid starting states are `develop` or `feature/developer/*`. If on `develop`, you will create a feature branch in Step 4 when picking up an issue. If on `feature/developer/<name>`, continue work on that branch. If on any other branch, stop and tell the user.
 - **test-engineer**: Valid starting states are `develop`, `feature/developer/*`, or `persona/test-engineer`. You will select the correct branch in Step 2 based on available work. If on any other branch, stop and tell the user.
 - **All other personas**: The current branch must match your persona's designated branch exactly. If not, tell the user which branch to switch to and stop.
+
+If persona is `triage`: print "The triage persona is invoked via /triage, not /watch-work. Run /triage instead." and stop.
 
 ---
 

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,25 @@
+name: Close Linked Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Close linked issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | while read num; do
+            echo "Closing issue #$num"
+            gh issue close "$num" --repo "$REPO" --comment "Closed automatically: fixed by PR #${{ github.event.pull_request.number }} merged to develop." || true
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 | **docs** | `persona/docs` | `docs/**`, `README.md`, `CLAUDE.md`, inline `// +kubebuilder:` marker comments |
 | **merge-manager** | — (no commits) | Creates GitHub issues and PR comments only |
 | **product-designer** | `persona/product-designer` | `.claude/plans/**`, GitHub Issues (create only), `docs/architecture.md` (joint with docs) |
+| **triage** | — (no commits) | Creates GitHub issues only; conducts human intake interview |
 
 ### Hard Rules
 
@@ -32,6 +33,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 - **docs** never modifies `*.go` files or `helm/templates/**`
 - **merge-manager** never commits code of any kind
 - **product-designer** never modifies source files of any kind; creates plans and GitHub issues only
+- **triage** never commits code, never modifies files, never creates plans; creates GitHub issues only after human confirmation
 
 ## Merge Manager Rules
 
@@ -59,6 +61,40 @@ The product designer is a trusted advisor and orchestrator, not an implementer. 
 7. Never merges PRs — gates and merges are the merge manager's responsibility
 
 To invoke: ask Claude to "act as product-designer" or check out `persona/product-designer`.
+
+## Triage Agent Rules
+
+The triage agent is an intake specialist, not an implementer. When invoked it:
+
+1. Conducts an interactive conversation to fully understand the issue being reported
+2. Asks clarifying questions until it has sufficient information to produce a complete report
+3. Determines the correct persona(s), phase, and type for each issue
+4. Presents a draft of every issue to the human for confirmation before creating anything
+5. Creates GitHub issues with correct `persona/<name>`, `phase/<n>`, and `type/<task|bug|security>` labels
+6. Creates multiple issues when a single incident spans multiple personas (e.g., a crash needs `persona/developer` + `type/bug` AND `persona/test-engineer` + `type/task`)
+7. Never commits code, never modifies any file, never creates `.claude/plans/` documents
+
+To invoke: run the `/triage` Claude Code skill.
+
+### Triage Routing Table
+
+| Symptom | Primary Issue | Secondary Issue |
+|---|---|---|
+| Code crash / broken functionality | `persona/developer` + `type/bug` | `persona/test-engineer` + `type/task` (if test coverage is missing) |
+| Usability confusion / unclear docs | `persona/docs` + `type/task` | — |
+| Security concern / RBAC / credential exposure | `persona/security` + `type/security` | — |
+| Architecture question / new feature design | `persona/product-designer` + `type/task` | — |
+| CI/CD failure / deployment issue / Helm chart bug | `persona/gitops-manager` + `type/bug` | — |
+| E2E / acceptance test failure | `persona/qa` + `type/bug` | — |
+
+### Phase Determination
+
+| Affected Component | Phase Label |
+|---|---|
+| `go.mod`, `Makefile`, `.github/workflows/**`, CI pipeline, module scaffolding | `phase/1-foundation` |
+| `internal/controller/**`, `internal/monitor/store.go`, `internal/scheduler/**`, `internal/gea/**` | `phase/2-core-logic` |
+| `internal/losant/**`, `internal/provisioner/**`, `api/v1alpha1/**`, Losant REST API, GEA MQTT | `phase/3-integration` |
+| `config/rbac/**`, `test/e2e/**`, `docs/runbook.md`, `docs/acceptance-criteria.md`, release pipeline | `phase/4-hardening` |
 
 ## Test Engineer Pairing Model
 
@@ -192,3 +228,5 @@ When creating issues, always apply:
 - A `type/task`, `type/bug`, or `type/security` label
 
 The merge manager uses these labels to route notifications and gate PRs.
+
+The triage agent does not apply a `persona/triage` label. It creates issues for other personas — it never owns an issue itself.

--- a/api/v1alpha1/losantsync_types.go
+++ b/api/v1alpha1/losantsync_types.go
@@ -141,6 +141,7 @@ type LosantSyncStatus struct {
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:printcolumn:name="Cluster",type=string,JSONPath=`.spec.clusterName`
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
+// +kubebuilder:printcolumn:name="GEA",type=string,JSONPath=`.status.conditions[?(@.type=="GEAReachable")].status`
 // +kubebuilder:printcolumn:name="Last Sync",type=date,JSONPath=`.status.lastSyncTime`
 // +kubebuilder:printcolumn:name="Next Sync",type=date,JSONPath=`.status.nextScheduledTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`

--- a/config/gea/deployment.yaml
+++ b/config/gea/deployment.yaml
@@ -50,15 +50,13 @@ spec:
             - name: gea-data
               mountPath: /data
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 30
             periodSeconds: 30
             failureThreshold: 3
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/mak3r/losant-device
-  newTag: latest
+  newTag: v0.1.0-alpha.6

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/mak3r/losant-device
-  newTag: v0.1.0-alpha.6
+  newTag: v0.1.0-alpha.7

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -221,3 +221,71 @@ Once the operator is running and reporting data, create the three-level dashboar
 3. **Node Dashboard**: add context variable for device ID; use single-device blocks for time-series
 
 See [docs/architecture.md](architecture.md#dashboard-hierarchy) for the full dashboard specification.
+
+---
+
+## Troubleshooting
+
+### Secret key names are wrong
+
+The GEA pod and the controller each require exact key names in their respective secrets. Hyphenated or lowercase variants are not accepted.
+
+| Secret | Required key names |
+|---|---|
+| `losant-gea-credentials` | `DEVICE_ID`, `ACCESS_KEY`, `ACCESS_SECRET` |
+| `losant-provisioning-credentials` | `api-token` |
+
+To verify the keys that are actually stored in a secret:
+
+```bash
+kubectl get secret losant-gea-credentials -n losant-system \
+  -o jsonpath='{.data}' | jq 'keys'
+```
+
+Expected output:
+```json
+["ACCESS_KEY", "ACCESS_SECRET", "DEVICE_ID"]
+```
+
+If any key is missing or named differently (e.g., `access-key`, `ACCESS-KEY`, `device_id`), delete and recreate the secret using the exact names shown in Step 6.
+
+---
+
+### GEA is in CrashLoopBackOff but the cluster looks healthy
+
+A failing liveness or readiness probe will cause Kubernetes to restart the GEA pod and report `CrashLoopBackOff`, even when the GEA has already established an MQTT connection to Losant. Check the logs before assuming the GEA itself is broken:
+
+```bash
+kubectl logs deploy/losant-gea -n losant-system
+```
+
+If the output contains the line:
+
+```
+Connected to: mqtts://broker.losant.com
+```
+
+the GEA is healthy. The restart loop is caused by a probe misconfiguration, not a GEA failure. Verify that the probe endpoint and port in your GEA deployment match the HTTP Trigger path (`/state`, port `8080`).
+
+---
+
+### Confirming the controller is reaching the GEA
+
+Once the GEA pod is stable (probes passing, no crash loop), confirm that the controller is successfully POSTing state to it:
+
+```bash
+# Watch the GEA pod logs for incoming requests
+kubectl logs deploy/losant-gea -n losant-system --follow
+
+# In another terminal, trigger a reconcile by patching the LosantSync
+kubectl annotate losantsync prod-edge-01 force-sync=$(date +%s) --overwrite
+```
+
+Each reconcile cycle should produce log lines similar to:
+
+```
+POST /state 200  deviceId=<cluster-device-id>
+POST /state 200  deviceId=<node-device-id>
+```
+
+If no POST lines appear, check that `LosantSync.spec.gea.serviceRef` and `.spec.gea.port` match the GEA service name and port (`losant-gea`, `8080`) in the cluster.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -200,6 +200,109 @@ kubectl patch losantsync my-cluster --type=merge -p '{"spec":{"suspend":false}}'
 
 ---
 
+## GEA Connectivity Troubleshooting
+
+The controller logs repeated errors like the following when it cannot reach the GEA pod:
+
+```
+ERROR  failed to report cluster state to GEA  {"error": "...connection refused"}
+```
+
+`kubectl get losantsync my-cluster -o yaml` will also show `phase: Degraded` and a condition:
+
+```yaml
+- type: GEAReachable
+  status: "False"
+  reason: GEAUnreachable
+  message: "connection refused"
+```
+
+### Step 1 — Check GEA pod status
+
+```bash
+kubectl get pods -n losant-system
+```
+
+Look for a pod whose name starts with `losant-gea-`. Expected status is `Running` with all containers ready. If the pod is in `CrashLoopBackOff`, `ImagePullBackOff`, `Pending`, or `Error`, proceed to the relevant cause below.
+
+### Step 2 — Check GEA pod logs
+
+```bash
+kubectl logs -n losant-system deploy/losant-gea
+```
+
+Look for MQTT connection errors, missing environment variables, or file-not-found messages pointing to a missing Secret or PVC mount.
+
+### Step 3 — Check service endpoints
+
+If the pod is running but the controller still cannot reach it, verify the Service has populated endpoints:
+
+```bash
+kubectl get endpoints -n losant-system losant-gea
+```
+
+Expected output shows at least one endpoint IP under `ENDPOINTS`. If the column shows `<none>`, the pod's labels do not match the Service selector — check `kubectl get pod -n losant-system --show-labels` against `kubectl get svc -n losant-system losant-gea -o yaml`.
+
+### Common causes and recovery steps
+
+**Image pull failure (`ImagePullBackOff` or `ErrImagePull`)**
+
+```bash
+kubectl describe pod -n losant-system <gea-pod-name>
+```
+
+Look for `Failed to pull image` in the Events section. Verify the image tag exists in the registry. Correct the tag in the GEA Deployment or Helm values, then apply the updated manifest.
+
+**Missing Secret**
+
+The GEA pod requires a Secret containing the Losant Edge Compute access key and secret. Check whether it exists:
+
+```bash
+kubectl get secret -n losant-system losant-gea-credentials
+```
+
+If missing, create it (see [docs/losant-setup.md](losant-setup.md) for the required fields), then delete and allow the pod to restart:
+
+```bash
+kubectl delete pod -n losant-system -l app=losant-gea
+```
+
+**Missing PVC**
+
+If the GEA pod mounts a PersistentVolumeClaim for its local datastore and the PVC is not bound:
+
+```bash
+kubectl get pvc -n losant-system
+```
+
+If the PVC is in `Pending` state, describe it to see why:
+
+```bash
+kubectl describe pvc -n losant-system <pvc-name>
+```
+
+On k3s, the default `local-path` StorageClass provisions PVCs lazily (on first pod mount). If the node has no available local-path provisioner pod, the PVC will stay `Pending` and the GEA pod will not start.
+
+**CrashLoopBackOff**
+
+```bash
+kubectl describe pod -n losant-system <gea-pod-name>
+```
+
+Check the `Last State` section for the exit code, and the Events section for OOM kills or liveness probe failures. Review logs from the previous container run:
+
+```bash
+kubectl logs -n losant-system <gea-pod-name> --previous
+```
+
+Fix the underlying cause (bad config, missing env var, or resource limit too low), then delete the pod to allow a clean restart:
+
+```bash
+kubectl delete pod -n losant-system -l app=losant-gea
+```
+
+---
+
 ## Suspending / Resuming Sync
 
 ```bash

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: losant-device
 description: Kubernetes operator that monitors cluster health and reports metrics to the Losant IoT platform
 type: application
 version: 0.1.0
-appVersion: latest
+appVersion: v0.1.0-alpha.7
 keywords:
   - losant
   - iot

--- a/helm/templates/gea-deployment.yaml
+++ b/helm/templates/gea-deployment.yaml
@@ -45,9 +45,13 @@ spec:
           volumeMounts:
             - name: gea-data
               mountPath: /data
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.gea.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.gea.service.port }}
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -164,7 +164,7 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		DeviceID:   clusterDeviceID,
 		Attributes: clusterAttributes(clusterSnapshot),
 	}); err != nil {
-		logger.Error(err, "failed to report cluster state to GEA")
+		logger.Info("GEA unreachable, will retry", "error", err.Error())
 		return r.setDegraded(ctx, &ls, "GEAReachable", "GEAUnreachable", err.Error())
 	}
 	setCondition(&ls, "GEAReachable", metav1.ConditionTrue, "Reachable", "GEA accepted cluster state")

--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -29,8 +29,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
 	"github.com/mak3r/losant-device/internal/gea"
@@ -206,7 +208,8 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 // SetupWithManager registers the controller with the manager.
 func (r *LosantSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&losantv1alpha1.LosantSync{}).
+		For(&losantv1alpha1.LosantSync{},
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(r)
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.6"
+const Version = "v0.1.0-alpha.7"


### PR DESCRIPTION
## Release v0.1.0-alpha.7

### What's included since v0.1.0-alpha.6

- **fix(helm)**: Switch GEA liveness/readiness probes from `httpGet /` to `tcpSocket` — edge agent only handles `POST /state`, so GET probes caused repeated restarts of a healthy pod (#182)
- **fix(controller)**: Add `GenerationChangedPredicate` to prevent status-update loops that bypassed `requeueOnDegraded` backoff (#179)
- **fix(controller)**: Downgrade GEA unreachable log from `Error` to `Info` to suppress spurious stack traces (#180)
- **feat(api)**: Add `GEAReachable` printer column to surface connectivity status in `kubectl get losantsyncs` (#183)
- **feat(ci)**: Auto-close linked issues when PR merges to develop (#176)
- **feat(ci)**: Dockerfile Go version drift check
- **docs**: GEA troubleshooting section, runbook updates
- **chore(config)**: Pin manager image tag from `:latest` to versioned tag

### Version bumps
- `internal/version/version.go`: `v0.1.0-alpha.6` → `v0.1.0-alpha.7`
- `helm/Chart.yaml` appVersion: `latest` → `v0.1.0-alpha.7`
- `config/manager/kustomization.yaml` image tag: `latest` → `v0.1.0-alpha.7`

### Post-merge
After merging, tag the resulting main commit with `v0.1.0-alpha.7` and push — this triggers `.github/workflows/release.yml` to build and push the multi-arch image and create the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)