### PR TITLE
fix(api): change Next Sync printer column type from date to string

### DIFF
--- a/api/v1alpha1/losantsync_types.go
+++ b/api/v1alpha1/losantsync_types.go
@@ -143,7 +143,7 @@ type LosantSyncStatus struct {
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="GEA",type=string,JSONPath=`.status.conditions[?(@.type=="GEAReachable")].status`
 // +kubebuilder:printcolumn:name="Last Sync",type=date,JSONPath=`.status.lastSyncTime`
-// +kubebuilder:printcolumn:name="Next Sync",type=date,JSONPath=`.status.nextScheduledTime`
+// +kubebuilder:printcolumn:name="Next Sync",type=string,JSONPath=`.status.nextScheduledTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // LosantSync is the Schema for the losantsyncs API.


### PR DESCRIPTION
## Summary
- Changes the `Next Sync` printer column from `type=date` to `type=string` in `api/v1alpha1/losantsync_types.go`
- Root cause: kubectl's `HumanDuration` returns `<invalid>` for negative durations — `time.Since(futureTime)` is always negative, so `type=date` can never render a future timestamp
- `type=string` shows the raw RFC3339 value (e.g. `2026-05-01T14:32:42Z`), which is accurate and readable

## Before / After
```
# Before
NAME       CLUSTER    PHASE    LAST SYNC   NEXT SYNC   AGE
home-lab   home-lab   Active   2m48s       <invalid>   44h

# After
NAME       CLUSTER    PHASE    LAST SYNC   NEXT SYNC              AGE
home-lab   home-lab   Active   2m48s       2026-05-01T14:32:42Z   44h
```

## Test plan
- [ ] `make test` passes
- [ ] `kubectl get losantsync` shows an RFC3339 timestamp in NEXT SYNC instead of `<invalid>`

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)