### PR TITLE
docs(losant-setup): specify HTTP Response Body Template in Step 4

### DIFF
--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -142,7 +142,12 @@ Because `deviceId` is included in every POST body, a single workflow handles bot
 8. From the HTTP Trigger, add a **Device: Set State** node
 9. Set the **Device** field to **Payload Path** and enter `data.body.deviceId`
 10. Set the **State** field to **Payload Path** and enter `data.body.data`
-11. Add a **HTTP Response** node after the Set State node; return status `200`
+11. Add a **HTTP Response** node after the Set State node:
+    - Set **Response Code** to `200`
+    - Set **Response Body Source** to **String Template**
+    - Set **Response Body Template** to `{}`
+
+    > The controller only checks the HTTP status code; the response body is ignored. `{}` is a valid minimal JSON body that satisfies the required field.
 
 ### Deploying the workflow
 


### PR DESCRIPTION
## Summary

- Step 4 step 11 now specifies all three HTTP Response node fields: Response Code (`200`), Response Body Source (String Template), and Response Body Template (`{}`)
- Adds a note clarifying that the controller only checks the status code — the body value is a required-but-ignored field

## Test plan

- [ ] Verify step 11 lists all three HTTP Response node fields
- [ ] Verify Response Body Template value is `{}`
- [ ] Verify the note about the controller ignoring the response body is present

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)