### PR TITLE
feat(makefile): add reset target for full cluster teardown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,12 @@ deploy: manifests ## Deploy the controller to the cluster with image substitutio
 undeploy: ## Remove the controller from the cluster
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: reset
+reset: ## Full teardown: undeploy operator, uninstall CRDs, delete losant-system namespace (idempotent)
+	$(MAKE) undeploy ignore-not-found=true
+	$(MAKE) uninstall ignore-not-found=true
+	kubectl delete namespace losant-system --ignore-not-found=true
+
 ##@ Dependencies
 
 LOCALBIN ?= $(shell pwd)/bin


### PR DESCRIPTION
## Summary

- Adds `make reset` target that performs a full cluster teardown in the correct order:
  1. `make undeploy ignore-not-found=true` — removes the operator and GEA deployments
  2. `make uninstall ignore-not-found=true` — removes CRDs
  3. `kubectl delete namespace losant-system --ignore-not-found=true` — removes all remaining cluster resources
- Idempotent: safe to run against an already-clean cluster (all steps use `--ignore-not-found=true`)
- Documented in `make help` output via the `##` comment

## Test plan

- [ ] `make help` output includes `reset` with the description
- [ ] Running `make reset` against a live cluster removes all resources
- [ ] Running `make reset` against a clean cluster (no resources) completes without errors

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)