### PR TITLE
docs(setup): add teardown and reset guide

### DIFF
--- a/docs/setup/5-teardown.md
+++ b/docs/setup/5-teardown.md
@@ -1,0 +1,83 @@
+# Step 5: Teardown and Reset
+
+Use this guide to completely remove a losant-device deployment — for example, to rebuild a test environment or recover from a corrupt state. Steps must be performed in order: cluster resources first, then Losant UI cleanup.
+
+> **Destructive operations ahead.** Deleting Losant devices removes all historical state data permanently. The GEA Access Secret is shown only once at creation — it cannot be recovered after the device is deleted. If you plan to redeploy, note down any IDs or tokens you will need to recreate.
+
+---
+
+## Part 1: Cluster Teardown (Automated)
+
+```bash
+make reset
+```
+
+This removes the operator, GEA pod, CRDs, RBAC resources, and the `losant-system` namespace in one step. It is equivalent to running `make undeploy` followed by `make uninstall`.
+
+Confirm everything is gone:
+
+```bash
+kubectl get namespace losant-system 2>&1
+# Expected: Error from server (NotFound): namespaces "losant-system" not found
+
+kubectl get crd losantsyncs.losant.io 2>&1
+# Expected: Error from server (NotFound): ...
+```
+
+If `make reset` is not available (older release), run the steps manually:
+
+```bash
+make undeploy    # removes operator, GEA, RBAC
+make uninstall   # removes CRDs
+kubectl delete namespace losant-system --ignore-not-found
+```
+
+---
+
+## Part 2: Losant UI Cleanup (Manual)
+
+These steps must be done in the Losant UI at [app.losant.com](https://app.losant.com). Each is destructive and cannot be undone.
+
+### 1. Delete peripheral (node) devices
+
+The operator provisioned one Losant device per k8s node. Delete them all before deleting the Edge Compute device.
+
+**Navigation:** Application → **Devices** → filter by tag `device_type=node` → select all → **Delete**
+
+> **Irreversible.** Deleting a device permanently removes all historical state data (time-series metrics, event logs) for that device.
+
+### 2. Delete the Edge Compute device (cluster device)
+
+**Navigation:** Application → **Devices** → select `cluster-<your-cluster-name>` → **Delete Device**
+
+> **Irreversible.** This also invalidates any Access Keys associated with the device. Delete the Access Key first if you want to audit its last-used date.
+
+### 3. Delete the Edge Workflow
+
+**Navigation:** Application → **Workflows** → select `k8s-state-receiver` (or your workflow name) → **Delete**
+
+### 4. Delete the GEA Access Key
+
+If the Access Key was not automatically invalidated when the Edge Compute device was deleted, remove it explicitly.
+
+**Navigation:** Application → **Security** → **Access Keys** → find the key named for the GEA → **Delete**
+
+### 5. Delete the Application API Token
+
+**Navigation:** Application → **Security** → **API Tokens** → find the token named `losant-device-controller` (or your token name) → **Delete**
+
+### 6. (Optional) Delete the Losant Application
+
+If you want a completely clean slate, delete the Application itself. This removes all devices, workflows, dashboards, and credentials in one operation.
+
+**Navigation:** Application → **Settings** → **Delete Application** → confirm
+
+> **Irreversible.** All data, devices, workflows, and API tokens under the Application are permanently deleted.
+
+---
+
+## Redeploying After Reset
+
+To start fresh after a full teardown, follow the setup guide from the beginning:
+
+**[Step 1 → Losant device setup](1-losant-device-setup.md)**

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -10,6 +10,7 @@ Complete setup for the losant-device operator requires steps in both the Losant 
 | [2. Cluster deployment](2-cluster-deployment.md) | Deploy the operator and GEA pod to the cluster | Yes |
 | [3. Losant workflow setup](3-losant-workflow-setup.md) | Create and deploy the Edge Workflow to the GEA | Yes — GEA must be Online |
 | [4. Operator configuration](4-operator-configuration.md) | (Optional) Device Recipe + apply the LosantSync CR | Yes |
+| [5. Teardown and reset](5-teardown.md) | Remove all cluster resources and Losant UI objects for a clean slate | Yes (for cluster steps) |
 
 > **Why this order?** Steps 1 and 2 are independent — you can create the Losant device and deploy the cluster in either order. Step 3 requires the GEA pod to have connected to Losant at least once (so Losant has an agent version on record). Step 4 requires the operator to be running.
 


### PR DESCRIPTION
## Summary

- Adds `docs/setup/5-teardown.md` with a full reset procedure: `make reset` for cluster teardown, then sequenced Losant UI steps (node devices → Edge Compute device → workflow → access key → API token → optional Application delete)
- Includes navigation paths for each UI step and destructive/irreversible warnings
- Updates `docs/setup/README.md` sequence table to include step 5

## Test plan

- [ ] Verify `docs/setup/5-teardown.md` exists with all required sections
- [ ] Verify `make reset` is referenced with fallback manual steps
- [ ] Verify each Losant UI step has a navigation path
- [ ] Verify destructive warning is present at the top
- [ ] Verify `docs/setup/README.md` sequence table includes step 5

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)