### PR TITLE
fix(docs): three setup guide corrections — step refs, namespace, make install ordering

### DIFF
--- a/docs/setup/1-losant-device-setup.md
+++ b/docs/setup/1-losant-device-setup.md
@@ -5,7 +5,7 @@ Configure the Losant Application and Edge Compute device. All steps in this docu
 ## Prerequisites
 
 - A Losant account at [app.losant.com](https://app.losant.com)
-- `kubectl` access to your cluster (for Step 6 — creating Kubernetes secrets)
+- `kubectl` access to your cluster (for Step 5 — creating Kubernetes secrets)
 
 > **Bootstrap constraint**: The cluster Edge Compute device (Step 2 below) must exist in Losant **before** the operator starts. The controller discovers and manages peripheral (node) devices automatically, but the cluster-level Edge Compute device must be pre-provisioned manually.
 

--- a/docs/setup/1-losant-device-setup.md
+++ b/docs/setup/1-losant-device-setup.md
@@ -81,6 +81,12 @@ The controller authenticates to the Losant REST API using a Losant Application A
 
 ## Step 5: Create Kubernetes Secrets
 
+The secrets must go into the `losant-system` namespace. Create it first — this command is idempotent and safe to re-run:
+
+```bash
+kubectl create namespace losant-system --dry-run=client -o yaml | kubectl apply -f -
+```
+
 ```bash
 # GEA credentials — mounted into the GEA pod as environment variables
 kubectl create secret generic losant-gea-credentials \

--- a/docs/setup/2-cluster-deployment.md
+++ b/docs/setup/2-cluster-deployment.md
@@ -24,15 +24,24 @@ kubectl create namespace losant-system
 
 This is the default path used in development and CI. The Makefile wraps `kubectl` and `kustomize` for each step.
 
-### Install CRDs only
+### Step 1: Install CRDs
 
 ```bash
 make install IMG=ghcr.io/mak3r/losant-device:latest
 ```
 
-Applies the `LosantSync` CRD from `config/crd/bases/` into the cluster. Safe to run repeatedly — it is idempotent.
+Registers the `LosantSync` CRD with the Kubernetes API server. **This must be run before `make deploy`.** The controller will fail immediately on startup with a "no matches for kind LosantSync" error if the CRD is not present.
 
-### Deploy controller + GEA
+Safe to run repeatedly — it is idempotent.
+
+Verify the CRD is registered:
+
+```bash
+kubectl get crd | grep losant.io
+# Expected: losantsyncs.losant.io   <timestamp>
+```
+
+### Step 2: Deploy controller + GEA
 
 ```bash
 make deploy IMG=ghcr.io/mak3r/losant-device:latest
@@ -55,6 +64,8 @@ make uninstall
 ```
 
 Deletes the `LosantSync` CRD. Any existing `LosantSync` CR objects will be garbage-collected.
+
+> **`make undeploy` vs. `make uninstall`**: `make undeploy` removes the controller Deployment, RBAC, and GEA resources, but leaves the CRD registered. `make uninstall` removes the CRD itself. For a full teardown, run `make undeploy` followed by `make uninstall` (or use `make reset` — see [Step 5: Teardown](5-teardown.md)).
 
 ---
 


### PR DESCRIPTION
## Summary

- **#205**: Corrects stale "Step 6" reference to "Step 5" in `1-losant-device-setup.md` Prerequisites
- **#206**: Adds idempotent namespace creation command at top of Step 5 (`1-losant-device-setup.md`) so secrets don't fail with namespace NotFound on fresh clusters
- **#207**: Clarifies `make install` is required before `make deploy` in `2-cluster-deployment.md`, adds CRD verification step, and adds a note distinguishing `make undeploy` (removes controller) from `make uninstall` (removes CRD)

## Test plan

- [ ] `1-losant-device-setup.md` Prerequisites references Step 5, not Step 6
- [ ] `1-losant-device-setup.md` Step 5 has namespace creation command before secret commands
- [ ] `2-cluster-deployment.md` labels `make install` as "Step 1" and `make deploy` as "Step 2"
- [ ] `2-cluster-deployment.md` has CRD verification: `kubectl get crd | grep losant.io`
- [ ] `2-cluster-deployment.md` Remove CRDs section explains undeploy vs uninstall distinction

Closes #205, #206, #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)