### PR TITLE
fix(makefile): make deploy installs CRDs first; confirm reset is complete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ uninstall: manifests ## Remove CRDs from the cluster (set ignore-not-found=true 
 	kubectl delete --ignore-not-found=$(ignore-not-found) -f config/crd/bases
 
 .PHONY: deploy
-deploy: manifests ## Deploy the controller to the cluster with image substitution (set IMG=<image>:<tag>)
+deploy: manifests install ## Deploy controller to cluster, installing CRDs first via kubectl apply (idempotent; set IMG=<image>:<tag>)
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 


### PR DESCRIPTION
## Summary

- **`make deploy`**: Added `install` as a prerequisite so the LosantSync CRD is always registered before the controller pod starts. `kubectl apply` is idempotent — running against an already-installed CRD is a no-op, so this is safe to call repeatedly.
- **`make reset`**: Confirmed complete — all three teardown steps (undeploy, uninstall, namespace deletion) were already present from #201.

## Decision rationale (option a vs b from #208)

Chose option **(a)** — `install` as a prerequisite — over a preflight check because:
- Zero extra shell code; the existing `install` target already uses `kubectl apply` which is idempotent
- Eliminates a failure class entirely rather than surfacing it as an error message
- Consistent with Kubernetes tooling conventions (kubebuilder scaffolds share this pattern)

## Test plan

- [ ] `make deploy` on a fresh cluster applies CRDs before starting the controller
- [ ] `make deploy` on a cluster where CRDs are already installed succeeds without error
- [ ] `make help` shows updated description for `deploy`
- [ ] `make reset` removes all resources (undeploy + uninstall + namespace)

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)