### PR TITLE
feat(helm): make GEA credentials Secret optional for auto-bootstrap

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -21,5 +21,8 @@ spec:
         - name: manager
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          env:
+            - name: GEA_DEPLOYMENT_REF
+              value: {{ if .Values.gea.deploymentRef }}{{ .Values.gea.deploymentRef | quote }}{{ else }}{{ printf "%s-gea" (include "losant-device.fullname" .) | quote }}{{ end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/helm/templates/secret-gea.yaml
+++ b/helm/templates/secret-gea.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.gea.credentials.existingSecret -}}
+{{- if and (not .Values.gea.credentials.existingSecret) (not .Values.gea.autoProvision) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -49,6 +49,8 @@
             "storageClassName": { "type": "string" }
           }
         },
+        "autoProvision": { "type": "boolean" },
+        "deploymentRef": { "type": "string" },
         "resources": { "type": "object" },
         "credentials": {
           "type": "object",

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -15,6 +15,12 @@ controller:
   logLevel: info
 
 gea:
+  # autoProvision: when true, the controller creates losant-gea-credentials automatically;
+  # Helm skips Secret creation to avoid overwriting controller-written credentials on upgrade.
+  autoProvision: true
+  # deploymentRef: name of the GEA Deployment used by the controller for rolling restarts
+  # after writing new credentials. Must match the deployed GEA Deployment name.
+  deploymentRef: ""
   image:
     repository: losant/edge-agent
     tag: latest


### PR DESCRIPTION
## Summary

- **`values.yaml`**: Added `gea.autoProvision: true` (default) and `gea.deploymentRef: ""` under the `gea:` section
- **`secret-gea.yaml`**: Added `not .Values.gea.autoProvision` guard — when `autoProvision=true` (default), Helm skips Secret creation so the controller can write credentials without them being overwritten on `helm upgrade`
- **`deployment.yaml`**: Added `GEA_DEPLOYMENT_REF` env var to the controller container; defaults to `<fullname>-gea` if `gea.deploymentRef` is not overridden, so the bootstrap logic knows which Deployment to rolling-restart after writing new credentials
- **`values.schema.json`**: Added `autoProvision: boolean` and `deploymentRef: string` to the `gea` object schema

## Behaviour matrix

| `autoProvision` | `existingSecret` | Secret rendered? |
|---|---|---|
| `true` (default) | any | No — controller bootstraps it |
| `false` | `""` (default) | Yes — from `secretValues` |
| `false` | `"my-secret"` | No — user-provided secret |

## Test plan

- [ ] `helm template . --set gea.autoProvision=true` (default) does not render `secret-gea.yaml`
- [ ] `helm template . --set gea.autoProvision=false` renders `secret-gea.yaml` with credential values
- [ ] `helm template . --set gea.credentials.existingSecret=foo` does not render `secret-gea.yaml`
- [ ] Controller deployment renders `GEA_DEPLOYMENT_REF` env var pointing to the correct GEA Deployment name

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)