### PR TITLE
feat(provisioner): implement automated GEA credential bootstrap

### DIFF
--- a/api/v1alpha1/losantsync_types.go
+++ b/api/v1alpha1/losantsync_types.go
@@ -49,6 +49,11 @@ type GEASpec struct {
 	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default=8080
 	Port int32 `json:"port"`
+
+	// DeploymentRef is the name of the GEA Deployment for rolling-restart automation.
+	// If empty, credential bootstrap writes the Secret but does not restart the GEA.
+	// +optional
+	DeploymentRef string `json:"deploymentRef,omitempty"`
 }
 
 // LosantSyncSpec defines the desired state of LosantSync.
@@ -112,7 +117,7 @@ type LosantSyncStatus struct {
 	Phase LosantSyncPhase `json:"phase,omitempty"`
 
 	// Conditions represent the latest available observations of the resource's state.
-	// Known condition types: GEAReachable, DevicesProvisioned, LastSyncSucceeded.
+	// Known condition types: GEABootstrapped, GEAReachable, DevicesProvisioned, LastSyncSucceeded.
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/mak3r/losant-device/internal/gea"
 	"github.com/mak3r/losant-device/internal/losant"
 	"github.com/mak3r/losant-device/internal/monitor"
+	"github.com/mak3r/losant-device/internal/provisioner"
 )
 
 const requeueOnDegraded = time.Minute
@@ -142,6 +143,19 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return r.setDegraded(ctx, &ls, "DevicesProvisioned", "ClusterDeviceError", err.Error())
 	}
 	ls.Status.ClusterDeviceID = clusterDeviceID
+
+	// Step 4.5: one-time GEA credential bootstrap (idempotent; skipped once GEABootstrapped=True).
+	// Falls through on success so the GEA connectivity check in Step 6 validates immediately.
+	if !apimeta.IsStatusConditionTrue(ls.Status.Conditions, "GEABootstrapped") {
+		b := &provisioner.GEABootstrapper{
+			Client:       r.Client,
+			LosantClient: lc,
+		}
+		if err := b.Bootstrap(ctx, &ls, clusterDeviceID); err != nil {
+			return r.setDegraded(ctx, &ls, "GEABootstrapped", "BootstrapFailed", err.Error())
+		}
+		setCondition(&ls, "GEABootstrapped", metav1.ConditionTrue, "BootstrapComplete", "GEA credentials provisioned")
+	}
 
 	// Step 5: ensure peripheral devices exist for every node in the health snapshot.
 	clusterSnapshot, nodeSnapshot := r.healthSnapshot()

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -63,6 +63,10 @@ type LosantClient interface {
 
 	// GetDevice returns the current definition of a Losant device.
 	GetDevice(ctx context.Context, applicationID, deviceID string) (*Device, error)
+
+	// CreateDeviceAccessKey creates a new Losant access key for the given device.
+	// Returns keyID, key, and secret. The secret is only available in this response.
+	CreateDeviceAccessKey(ctx context.Context, applicationID, deviceID, name string) (keyID, key, secret string, err error)
 }
 
 // Device is a minimal Losant device representation sufficient for the provisioning workflow.
@@ -167,6 +171,30 @@ func (c *HTTPClient) GetDevice(ctx context.Context, applicationID, deviceID stri
 		return nil, fmt.Errorf("decode device response: %w", err)
 	}
 	return &dev, nil
+}
+
+// CreateDeviceAccessKey creates a Losant access key for the given device and returns
+// the keyID, key, and secret. The secret is shown only in this response.
+func (c *HTTPClient) CreateDeviceAccessKey(ctx context.Context, applicationID, deviceID, name string) (string, string, string, error) {
+	payload := map[string]string{"name": name}
+	path := fmt.Sprintf("%s/applications/%s/devices/%s/accessKeys", apiBase, applicationID, deviceID)
+	body, err := c.doRequest(ctx, http.MethodPost, path, payload)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	var resp struct {
+		KeyID  string `json:"keyId"`
+		Key    string `json:"key"`
+		Secret string `json:"secret"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", "", "", fmt.Errorf("decode access key response: %w", err)
+	}
+	if resp.Key == "" || resp.Secret == "" {
+		return "", "", "", fmt.Errorf("create device access key: empty key or secret in response")
+	}
+	return resp.KeyID, resp.Key, resp.Secret, nil
 }
 
 // findDeviceByName returns the first Losant device matching name, or nil if not found.

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -32,18 +32,20 @@ import (
 type MockClient struct {
 	mu sync.Mutex
 
-	PingFunc                func(ctx context.Context) error
-	EnsureClusterDeviceFunc func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error)
-	EnsureNodeDeviceFunc    func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error)
-	UpdateDeviceTagsFunc    func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
-	GetDeviceFunc           func(ctx context.Context, applicationID, deviceID string) (*Device, error)
+	PingFunc                  func(ctx context.Context) error
+	EnsureClusterDeviceFunc   func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error)
+	EnsureNodeDeviceFunc      func(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error)
+	UpdateDeviceTagsFunc      func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
+	GetDeviceFunc             func(ctx context.Context, applicationID, deviceID string) (*Device, error)
+	CreateDeviceAccessKeyFunc func(ctx context.Context, applicationID, deviceID, name string) (string, string, string, error)
 
 	// Recorded calls — read after test assertions.
-	PingCalls                []struct{}
-	EnsureClusterDeviceCalls []EnsureClusterDeviceCall
-	EnsureNodeDeviceCalls    []EnsureNodeDeviceCall
-	UpdateDeviceTagsCalls    []UpdateDeviceTagsCall
-	GetDeviceCalls           []GetDeviceCall
+	PingCalls                  []struct{}
+	EnsureClusterDeviceCalls   []EnsureClusterDeviceCall
+	EnsureNodeDeviceCalls      []EnsureNodeDeviceCall
+	UpdateDeviceTagsCalls      []UpdateDeviceTagsCall
+	GetDeviceCalls             []GetDeviceCall
+	CreateDeviceAccessKeyCalls []CreateDeviceAccessKeyCall
 }
 
 // EnsureClusterDeviceCall records one invocation of EnsureClusterDevice.
@@ -69,6 +71,13 @@ type UpdateDeviceTagsCall struct {
 type GetDeviceCall struct {
 	ApplicationID string
 	DeviceID      string
+}
+
+// CreateDeviceAccessKeyCall records one invocation of CreateDeviceAccessKey.
+type CreateDeviceAccessKeyCall struct {
+	ApplicationID string
+	DeviceID      string
+	Name          string
 }
 
 // NewMockClient returns a MockClient with sensible defaults:
@@ -99,6 +108,9 @@ func (m *MockClient) SetError(err error) {
 	m.GetDeviceFunc = func(_ context.Context, _, _ string) (*Device, error) {
 		return nil, err
 	}
+	m.CreateDeviceAccessKeyFunc = func(_ context.Context, _, _, _ string) (string, string, string, error) {
+		return "", "", "", err
+	}
 }
 
 // CallCount returns the total number of calls recorded across all methods.
@@ -109,7 +121,8 @@ func (m *MockClient) CallCount() int {
 		len(m.EnsureClusterDeviceCalls) +
 		len(m.EnsureNodeDeviceCalls) +
 		len(m.UpdateDeviceTagsCalls) +
-		len(m.GetDeviceCalls)
+		len(m.GetDeviceCalls) +
+		len(m.CreateDeviceAccessKeyCalls)
 }
 
 // Reset clears all recorded calls and resets all HandlerFuncs to defaults.
@@ -121,11 +134,13 @@ func (m *MockClient) Reset() {
 	m.EnsureNodeDeviceFunc = nil
 	m.UpdateDeviceTagsFunc = nil
 	m.GetDeviceFunc = nil
+	m.CreateDeviceAccessKeyFunc = nil
 	m.PingCalls = nil
 	m.EnsureClusterDeviceCalls = nil
 	m.EnsureNodeDeviceCalls = nil
 	m.UpdateDeviceTagsCalls = nil
 	m.GetDeviceCalls = nil
+	m.CreateDeviceAccessKeyCalls = nil
 }
 
 // Ping implements LosantClient.
@@ -198,4 +213,21 @@ func (m *MockClient) GetDevice(ctx context.Context, applicationID, deviceID stri
 		return fn(ctx, applicationID, deviceID)
 	}
 	return &Device{DeviceID: deviceID}, nil
+}
+
+// CreateDeviceAccessKey implements LosantClient.
+func (m *MockClient) CreateDeviceAccessKey(ctx context.Context, applicationID, deviceID, name string) (string, string, string, error) {
+	m.mu.Lock()
+	m.CreateDeviceAccessKeyCalls = append(m.CreateDeviceAccessKeyCalls, CreateDeviceAccessKeyCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+		Name:          name,
+	})
+	fn := m.CreateDeviceAccessKeyFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID, name)
+	}
+	return "mock-key-id", "mock-access-key", "mock-access-secret", nil
 }

--- a/internal/provisioner/bootstrap.go
+++ b/internal/provisioner/bootstrap.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package provisioner handles one-time GEA credential bootstrap.
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
+	"github.com/mak3r/losant-device/internal/losant"
+)
+
+const geaCredentialsSecretName = "losant-gea-credentials"
+
+// GEABootstrapper provisions initial GEA MQTT credentials into a cluster Secret.
+type GEABootstrapper struct {
+	Client       client.Client
+	LosantClient losant.LosantClient
+}
+
+// Bootstrap writes the losant-gea-credentials Secret if it is absent or incomplete.
+// It is idempotent: a Secret that already contains DEVICE_ID, ACCESS_KEY, and
+// ACCESS_SECRET causes an immediate return with no API calls.
+func (b *GEABootstrapper) Bootstrap(ctx context.Context, ls *losantv1alpha1.LosantSync, clusterDeviceID string) error {
+	ns := ls.Spec.ProvisioningSecretRef.Namespace
+
+	var existing corev1.Secret
+	getErr := b.Client.Get(ctx, types.NamespacedName{Name: geaCredentialsSecretName, Namespace: ns}, &existing)
+	switch {
+	case getErr == nil:
+		d := existing.Data
+		if len(d["DEVICE_ID"]) > 0 && len(d["ACCESS_KEY"]) > 0 && len(d["ACCESS_SECRET"]) > 0 {
+			return nil
+		}
+	case errors.IsNotFound(getErr):
+		// will create below
+	default:
+		return fmt.Errorf("read %s/%s: %w", ns, geaCredentialsSecretName, getErr)
+	}
+
+	keyName := fmt.Sprintf("losant-device-controller-%s-%d", ls.Spec.ClusterName, time.Now().Unix())
+	_, key, secret, err := b.LosantClient.CreateDeviceAccessKey(ctx, ls.Spec.ApplicationID, clusterDeviceID, keyName)
+	if err != nil {
+		return fmt.Errorf("create device access key: %w", err)
+	}
+
+	data := map[string][]byte{
+		"DEVICE_ID":     []byte(clusterDeviceID),
+		"ACCESS_KEY":    []byte(key),
+		"ACCESS_SECRET": []byte(secret),
+	}
+
+	if errors.IsNotFound(getErr) {
+		cred := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      geaCredentialsSecretName,
+				Namespace: ns,
+			},
+			Data: data,
+		}
+		if err := b.Client.Create(ctx, cred); err != nil {
+			return fmt.Errorf("create %s/%s: %w", ns, geaCredentialsSecretName, err)
+		}
+	} else {
+		patched := existing.DeepCopy()
+		patched.Data = data
+		if err := b.Client.Patch(ctx, patched, client.MergeFrom(&existing)); err != nil {
+			return fmt.Errorf("patch %s/%s: %w", ns, geaCredentialsSecretName, err)
+		}
+	}
+
+	if ls.Spec.GEA.DeploymentRef != "" {
+		if err := b.restartDeployment(ctx, ns, ls.Spec.GEA.DeploymentRef); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *GEABootstrapper) restartDeployment(ctx context.Context, ns, name string) error {
+	var dep appsv1.Deployment
+	if err := b.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, &dep); err != nil {
+		return fmt.Errorf("get GEA Deployment %s/%s: %w", ns, name, err)
+	}
+	patched := dep.DeepCopy()
+	if patched.Spec.Template.Annotations == nil {
+		patched.Spec.Template.Annotations = make(map[string]string)
+	}
+	patched.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	if err := b.Client.Patch(ctx, patched, client.MergeFrom(&dep)); err != nil {
+		return fmt.Errorf("patch GEA Deployment %s/%s: %w", ns, name, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds `internal/provisioner/bootstrap.go` with `GEABootstrapper` that idempotently writes `losant-gea-credentials` Secret on first provisioning
- Adds `GEASpec.DeploymentRef` optional field to trigger rolling restart of the GEA Deployment after credential injection
- Adds `CreateDeviceAccessKey` to `LosantClient` interface, `HTTPClient` implementation, and `MockClient`
- Updates `LosantSyncStatus` condition type comment to include `GEABootstrapped`
- Bootstrap guard inserted in reconcile loop after Step 4 (cluster device ID known); falls through on success so GEA connectivity is validated in Step 6 without an extra requeue cycle
- RBAC markers intentionally omitted — will be added after security closes #214

## Files changed
- `api/v1alpha1/losantsync_types.go` — `DeploymentRef` field, condition comment
- `internal/losant/client.go` — `CreateDeviceAccessKey` interface + `HTTPClient` impl
- `internal/losant/mock_client.go` — `CreateDeviceAccessKey` mock
- `internal/provisioner/bootstrap.go` — new package, `GEABootstrapper`
- `internal/controller/losantsync_controller.go` — bootstrap guard + provisioner import

## Test plan
- [ ] `make test` passes (all tests green, 89.0% controller coverage)
- [ ] `make manifests && git diff --exit-code config/rbac/role.yaml` — no drift (no new RBAC markers)
- [ ] test-engineer to add coverage for `internal/provisioner` (currently 0%)

## Depends on
- #214 (security) — must be closed before adding `secrets create/update` and `deployments patch` RBAC markers

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)