### PR TITLE
docs(setup): update for automated GEA credential bootstrap

### DIFF
--- a/docs/setup/1-losant-device-setup.md
+++ b/docs/setup/1-losant-device-setup.md
@@ -1,13 +1,25 @@
 # Step 1: Losant Device Setup
 
-Configure the Losant Application and Edge Compute device. All steps in this document are performed in the Losant UI — no running cluster is required.
+Configure the Losant Application and the API credentials the controller needs. The controller now handles Edge Compute device creation and GEA credential bootstrap automatically.
+
+## Quick Start
+
+You only need to perform three manual steps before deploying:
+
+1. **Create a Losant Application** (Step 1 below)
+2. **Create an Application API Token** (Step 2 below)
+3. **Create the provisioning Kubernetes Secret** with that token (Step 3 below)
+
+The controller provisions the Edge Compute device, GEA Access Key, and `losant-gea-credentials` Secret automatically on first reconcile. See [Step 4](4-operator-configuration.md) for applying the LosantSync CR that triggers provisioning.
+
+---
 
 ## Prerequisites
 
 - A Losant account at [app.losant.com](https://app.losant.com)
-- `kubectl` access to your cluster (for Step 5 — creating Kubernetes secrets)
+- `kubectl` access to your cluster (for Step 3 — creating the Kubernetes secret)
 
-> **Bootstrap constraint**: The cluster Edge Compute device (Step 2 below) must exist in Losant **before** the operator starts. The controller discovers and manages peripheral (node) devices automatically, but the cluster-level Edge Compute device must be pre-provisioned manually.
+> **Auto-provisioning**: The controller creates the cluster Edge Compute device and all GEA credentials automatically on first reconcile. Manual device creation is no longer required for standard deployments. See [Advanced: Manual Pre-Provisioning](#advanced-manual-pre-provisioning) at the bottom of this page for environments where outbound REST calls from the controller are restricted.
 
 ---
 
@@ -20,24 +32,64 @@ Configure the Losant Application and Edge Compute device. All steps in this docu
 
 ---
 
-## Step 2: Create the Edge Compute Device (Cluster Device)
+## Step 2: Create an Application API Token
 
-This device represents the cluster in Losant. Its credentials are used by the GEA pod.
+The controller authenticates to the Losant REST API using a Losant Application API Token — **not** a device access key. Device access keys are MQTT-only credentials; they cannot make REST API calls.
 
-1. Inside your Application, click **Devices** → **Add Device**
-2. Choose device type: **Edge Compute**
-3. Name it `cluster-<your-cluster-name>` (e.g., `cluster-prod-edge-01`)
-4. Add the following tags (these can also be managed by the controller at runtime):
-   ```
-   device_type  = cluster
-   cluster_name = <your-cluster-name>
-   region       = <your-region>
-   health_status = provisioning
-   ```
+1. In your Application → **Security** → **API Tokens** → **Add API Token**
+2. Give it a name (e.g., `losant-device-controller`)
+3. Set the expiration as appropriate for your security policy (or leave as no expiration)
+4. Note the **API Token** value (shown only once)
 
-   > **Tags vs. Attributes**: Losant *tags* are device metadata used for filtering and search — they are not time-series data. Losant *attributes* store state values reported over time (what the controller POSTs on every sync). `health_status` appears as both: a tag that holds the initial provisioning state and an attribute that receives ongoing string state updates from the controller. You must create it in the Attributes list below so the controller's state reports are accepted.
+---
 
-5. Under **Attributes**, add these grouped by type:
+## Step 3: Create the Provisioning Kubernetes Secret
+
+The secret must go into the `losant-system` namespace. Create it first — this command is idempotent and safe to re-run:
+
+```bash
+kubectl create namespace losant-system --dry-run=client -o yaml | kubectl apply -f -
+```
+
+```bash
+# Provisioning credentials — used by the controller for Losant REST API calls
+kubectl create secret generic losant-provisioning-credentials \
+  --from-literal=api-token=<application-api-token-from-step-2> \
+  -n losant-system
+```
+
+> **Key name matters**: The controller reads a single `api-token` key from this secret. Using any other key name will cause the operator to fail at startup with a missing-key error.
+
+---
+
+## Next step
+
+**[Step 2 → Cluster deployment](2-cluster-deployment.md)** — deploy the operator and GEA pod to the cluster.
+
+---
+
+## Advanced: Manual Pre-Provisioning
+
+For environments where the operator cannot make outbound REST API calls to `api.losant.com` at startup (e.g., strict egress firewall rules), you can disable auto-provisioning and create the cluster device manually.
+
+Deploy with auto-provisioning disabled:
+
+```bash
+# Helm
+helm install losant-device helm/ \
+  --namespace losant-system \
+  --create-namespace \
+  --set gea.autoProvision=false \
+  ...
+
+# Kustomize — set the GEA_AUTO_PROVISION=false env var in a kustomize overlay
+```
+
+When `autoProvision=false`, complete these manual steps **before** deploying:
+
+1. **Create the Edge Compute device** in Losant: Application → **Devices** → **Add Device** → **Edge Compute**
+
+   Under **Attributes**, add these grouped by type:
 
    **Number** (data type: `number`):
    ```
@@ -55,61 +107,18 @@ This device represents the cluster in Losant. Its credentials are used by the GE
    ```
    health_status
    ```
-6. Note the **Device ID** — this is the GEA's identity
 
----
+   Note the **Device ID**.
 
-## Step 3: Create the GEA Access Key
+2. **Create a GEA Access Key**: on the device page → **Security** → **Add Access Key**. Note the **Access Key** and **Access Secret** (shown only once).
 
-The GEA pod needs its own credentials to authenticate to Losant as the Edge Compute device.
+3. **Create the `losant-gea-credentials` secret**:
+   ```bash
+   kubectl create secret generic losant-gea-credentials \
+     --from-literal=DEVICE_ID=<edge-compute-device-id> \
+     --from-literal=ACCESS_KEY=<gea-access-key> \
+     --from-literal=ACCESS_SECRET=<gea-access-secret> \
+     -n losant-system
+   ```
 
-1. On the Edge Compute device page → **Security** → **Add Access Key**
-2. Note the **Access Key** and **Access Secret** (the secret is shown only once)
-
----
-
-## Step 4: Create an Application API Token
-
-The controller authenticates to the Losant REST API using a Losant Application API Token — **not** a device access key. Device access keys are MQTT-only credentials used by the GEA pod; they cannot make REST API calls.
-
-1. In your Application → **Security** → **API Tokens** → **Add API Token**
-2. Give it a name (e.g., `losant-device-controller`)
-3. Set the expiration as appropriate for your security policy (or leave as no expiration)
-4. Note the **API Token** value (shown only once)
-
----
-
-## Step 5: Create Kubernetes Secrets
-
-The secrets must go into the `losant-system` namespace. Create it first — this command is idempotent and safe to re-run:
-
-```bash
-kubectl create namespace losant-system --dry-run=client -o yaml | kubectl apply -f -
-```
-
-```bash
-# GEA credentials — mounted into the GEA pod as environment variables
-kubectl create secret generic losant-gea-credentials \
-  --from-literal=DEVICE_ID=<edge-compute-device-id-from-step-2> \
-  --from-literal=ACCESS_KEY=<gea-access-key-from-step-3> \
-  --from-literal=ACCESS_SECRET=<gea-access-secret-from-step-3> \
-  -n losant-system
-
-# Provisioning credentials — used by the controller for Losant REST API calls
-kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=api-token=<application-api-token-from-step-4> \
-  -n losant-system
-```
-
-> **Key name matters**: The GEA secret requires uppercase `DEVICE_ID`, `ACCESS_KEY`, `ACCESS_SECRET`. The controller secret requires lowercase `api-token`. Using any other key names will cause the respective component to fail at startup. To verify:
-> ```bash
-> kubectl get secret losant-gea-credentials -n losant-system \
->   -o jsonpath='{.data}' | jq 'keys'
-> # Expected: ["ACCESS_KEY", "ACCESS_SECRET", "DEVICE_ID"]
-> ```
-
----
-
-## Next step
-
-**[Step 2 → Cluster deployment](2-cluster-deployment.md)** — deploy the operator and GEA pod to the cluster.
+The controller will use this pre-existing secret and will not attempt to provision a device via the REST API.

--- a/docs/setup/3-losant-workflow-setup.md
+++ b/docs/setup/3-losant-workflow-setup.md
@@ -4,9 +4,12 @@ Create and deploy the Edge Workflow that receives state reports from the control
 
 ## Prerequisites
 
+- LosantSync CR applied and at least one reconcile completed (see [Step 4](4-operator-configuration.md)) — the controller creates the Edge Compute device automatically on first reconcile, typically within 30 seconds
 - GEA pod deployed and showing **Online** status in Losant (see [Step 2](2-cluster-deployment.md))
 
-> If the device is not Online, do not proceed — the workflow deployment will fail with: *"Some of your selected devices have an agent version lower than the target version for this deployment."* This means the GEA has not yet registered an agent version with Losant.
+> **Wait for the device to appear**: The Edge Compute device is provisioned by the controller on first reconcile. If you have not yet applied the LosantSync CR, do that now ([Step 4](4-operator-configuration.md)) and wait ~30 seconds for the device to appear in **Application → Devices** before creating the workflow.
+
+> If the device is not Online when you attempt to deploy the workflow, the deployment will fail with: *"Some of your selected devices have an agent version lower than the target version for this deployment."* This means the GEA has not yet registered an agent version with Losant.
 
 ---
 
@@ -14,7 +17,7 @@ Create and deploy the Edge Workflow that receives state reports from the control
 
 1. In your Application → **Workflows** → **Add Workflow** → **Edge Workflow**
 2. Give the workflow a name (e.g., `k8s-state-receiver`)
-3. Under **Edge Devices**, select the Edge Compute device you created in [Step 1](1-losant-device-setup.md)
+3. Under **Edge Devices**, select the Edge Compute device provisioned by the controller (visible in **Application → Devices** after first reconcile)
 
 > **Note on Device trigger blocks**: The Losant workflow editor shows cloud-side trigger nodes labelled "Device" (command, connect, disconnect, startup). These fire on MQTT events from a cloud perspective and are **not** what you need here. You need an **HTTP Trigger** node, which is an edge-side trigger that listens for local HTTP requests on the GEA pod.
 

--- a/docs/setup/4-operator-configuration.md
+++ b/docs/setup/4-operator-configuration.md
@@ -52,28 +52,6 @@ kubectl get losantsync prod-edge-01 -w
 
 See [docs/architecture.md](../architecture.md#crd-losantsync) for the full CRD field reference.
 
-> **Known issue — cluster device duplication**: The controller's provisioner will create a second Edge Compute device in Losant if it cannot match `LosantSync.spec.clusterName` to the device you created manually in [Step 1](1-losant-device-setup.md). Until automated provisioning matching is fully implemented, you may see two cluster-level devices in the Losant UI after the first reconcile.
->
-> **Workaround:**
-> 1. In the Losant UI, identify the controller-created device (it will have tags set by the controller, such as `health_status=provisioning`)
-> 2. Note its **Device ID**
-> 3. Delete the original manually created device
-> 4. Update the `DEVICE_ID` key in the `losant-gea-credentials` secret to the controller-created device's ID:
->    ```bash
->    kubectl create secret generic losant-gea-credentials \
->      --from-literal=DEVICE_ID=<controller-created-device-id> \
->      --from-literal=ACCESS_KEY=<existing-access-key> \
->      --from-literal=ACCESS_SECRET=<existing-access-secret> \
->      -n losant-system \
->      --dry-run=client -o yaml | kubectl apply -f -
->    ```
-> 5. Restart the GEA pod to pick up the new `DEVICE_ID`:
->    ```bash
->    kubectl rollout restart deployment/losant-gea -n losant-system
->    ```
->
-> This workaround will be removed once issue #211 (automated provisioning matching) is resolved.
-
 ---
 
 ## Dashboard Setup

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -6,7 +6,7 @@ Complete setup for the losant-device operator requires steps in both the Losant 
 
 | Step | What happens | Requires cluster? |
 |---|---|---|
-| [1. Losant device setup](1-losant-device-setup.md) | Create Losant Application, Edge Compute device, access key, API token, and Kubernetes secrets | No — UI only |
+| [1. Losant device setup](1-losant-device-setup.md) | Create Losant Application, API token, and provisioning Kubernetes secret (device and GEA credentials are auto-provisioned by the controller) | No — UI + kubectl |
 | [2. Cluster deployment](2-cluster-deployment.md) | Deploy the operator and GEA pod to the cluster | Yes |
 | [3. Losant workflow setup](3-losant-workflow-setup.md) | Create and deploy the Edge Workflow to the GEA | Yes — GEA must be Online |
 | [4. Operator configuration](4-operator-configuration.md) | (Optional) Device Recipe + apply the LosantSync CR | Yes |


### PR DESCRIPTION
## Summary

Follows the merge of #215 (automated GEA credential bootstrap).

- **`1-losant-device-setup.md`**: Removes Steps 2 (Edge Compute device) and 3 (GEA Access Key) — now automated. Renumbers remaining steps to 1–3. Removes `losant-gea-credentials` from required secrets. Adds Quick Start summary. Adds Advanced: Manual Pre-Provisioning section with `gea.autoProvision=false` reference.
- **`3-losant-workflow-setup.md`**: Updates prereqs to note device appears after first reconcile; references `4-operator-configuration.md` for applying LosantSync CR first. Fixes device reference from "created in Step 1" to "provisioned by the controller".
- **`4-operator-configuration.md`**: Removes obsolete device duplication workaround (added in #212, now superseded).
- **`setup/README.md`**: Updates Step 1 description in sequence table.

## Test plan

- [ ] `1-losant-device-setup.md` has only 3 steps (Application, API Token, Secret)
- [ ] `1-losant-device-setup.md` has Quick Start summary section
- [ ] `1-losant-device-setup.md` has Advanced: Manual Pre-Provisioning section with `gea.autoProvision=false`
- [ ] `3-losant-workflow-setup.md` prereqs mention applying LosantSync CR first
- [ ] `3-losant-workflow-setup.md` device reference is "provisioned by the controller"
- [ ] `4-operator-configuration.md` has no device duplication warning
- [ ] No broken cross-references

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)