### PR TITLE
feat(rbac): approve secrets create/update and deployments patch for GEA bootstrap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,10 +20,19 @@ rules:
   - nodes
   - persistentvolumeclaims
   - pods
-  - secrets
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - apps
@@ -32,6 +41,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,15 +8,6 @@ rules:
   - ""
   resources:
   - events
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   - persistentvolumeclaims
   - pods
@@ -29,9 +20,7 @@ rules:
   resources:
   - secrets
   verbs:
-  - create
   - get
-  - update
 - apiGroups:
   - apps
   resources:
@@ -39,7 +28,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,11 +20,18 @@ rules:
   - nodes
   - persistentvolumeclaims
   - pods
-  - secrets
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - apps
   resources:
@@ -32,6 +39,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,19 +8,23 @@ rules:
   - ""
   resources:
   - events
-  - nodes
-  - persistentvolumeclaims
-  - pods
   verbs:
+  - create
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""
   resources:
+  - nodes
+  - persistentvolumeclaims
+  - pods
   - secrets
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
## Summary

Approves the RBAC permissions required for the automated GEA credential bootstrap provisioner (issue #214):

- **`core/secrets`**: adds `create` and `update` to existing `get;list;watch` — provisioner writes the GEA credential Secret
- **`apps/deployments`**: adds `patch` to existing `get;list;watch` — provisioner triggers rolling restart via annotation patch

## CI note — expected drift check failure

The manifest-drift check will be **red on this PR** until developer PR #215 merges to develop. The drift check runs against the merge commit of `persona/security + develop`; develop's Go files currently only have `secrets: get;list;watch` and `deployments: get;list;watch` in their kubebuilder markers. Once the developer adds `create;update` to secrets and `patch` to deployments in their markers and that PR merges, the drift check will pass on this PR.

**This is expected behavior for security pre-approval.** The merge-manager should hold this PR until #215 is merged.

## Closes

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)