### PR TITLE
feat(rbac): add secrets create/update and deployments patch markers for GEA bootstrap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,10 +20,19 @@ rules:
   - nodes
   - persistentvolumeclaims
   - pods
-  - secrets
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - apps
@@ -32,6 +41,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -55,12 +55,12 @@ type LosantSyncReconciler struct {
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;get;list;patch;watch
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
 
 func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
## Summary
- Adds `create` and `update` verbs to the `secrets` RBAC marker (was `get;list;watch`)
- Adds `patch` verb to the `deployments` RBAC marker (was `get;list;watch`)
- Regenerates `config/rbac/role.yaml` from the expanded markers

These permissions are required by `GEABootstrapper` (merged in #220) to write
the `losant-gea-credentials` Secret and trigger a GEA rolling restart.

## Security approval
Permissions were pre-approved by the security persona in #214. The exact marker
form was specified by security in the issue comments:
```
// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update
// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;patch
```

The `role.yaml` changes are a mechanical regeneration (`make manifests`) driven by these markers.

## Test plan
- [ ] `make test` passes
- [ ] `make manifests && git diff --exit-code config/rbac/role.yaml` — no drift

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)