### PR TITLE
feat(helm): add init container to wait for GEA credentials secret

### DIFF
--- a/config/gea/deployment.yaml
+++ b/config/gea/deployment.yaml
@@ -16,6 +16,16 @@ spec:
         app: losant-gea
     spec:
       serviceAccountName: losant-gea
+      initContainers:
+        - name: wait-for-credentials
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - 'until [ -s /tmp/gea-creds/DEVICE_ID ]; do echo "waiting for GEA credentials secret"; sleep 5; done'
+          volumeMounts:
+            - name: gea-credentials-probe
+              mountPath: /tmp/gea-creds
       containers:
         - name: edge-agent
           image: losant/edge-agent:latest
@@ -61,6 +71,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
       volumes:
+        - name: gea-credentials-probe
+          secret:
+            secretName: losant-gea-credentials
+            optional: true
         - name: gea-data
           persistentVolumeClaim:
             claimName: losant-gea-data

--- a/helm/templates/gea-deployment.yaml
+++ b/helm/templates/gea-deployment.yaml
@@ -17,6 +17,16 @@ spec:
         app: {{ include "losant-device.fullname" . }}-gea
     spec:
       serviceAccountName: {{ include "losant-device.fullname" . }}-gea
+      initContainers:
+        - name: wait-for-credentials
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - 'until [ -s /tmp/gea-creds/DEVICE_ID ]; do echo "waiting for GEA credentials secret"; sleep 5; done'
+          volumeMounts:
+            - name: gea-credentials-probe
+              mountPath: /tmp/gea-creds
       containers:
         - name: edge-agent
           image: "{{ .Values.gea.image.repository }}:{{ .Values.gea.image.tag }}"
@@ -56,6 +66,10 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
       volumes:
+        - name: gea-credentials-probe
+          secret:
+            secretName: {{ include "losant-device.geaSecretName" . }}
+            optional: true
         - name: gea-data
           persistentVolumeClaim:
             claimName: {{ include "losant-device.fullname" . }}-gea-data


### PR DESCRIPTION
## Summary

- Adds a `wait-for-credentials` init container to both `helm/templates/gea-deployment.yaml` and `config/gea/deployment.yaml`
- The init container mounts `losant-gea-credentials` as an **optional** secret volume at `/tmp/gea-creds` and polls until `DEVICE_ID` is non-empty (`-s` test)
- The pod stays in `Init:0/1` state (no `CrashLoopBackOff`, no exponential backoff) while waiting
- Kubernetes updates projected secret volumes within ~30 seconds of secret creation, so the GEA pod progresses to `Running/Ready` within one controller reconcile cycle — no manual `kubectl delete pod` required
- No RBAC changes needed: the init container reads a mounted file, not the Kubernetes API

## Why init container over optional secretKeyRef

`optional: true` secretKeyRef lets the pod start with empty env vars and enter CrashLoopBackOff. With exponential backoff (max 5 min), recovery can be significantly delayed. The init container avoids that entirely by keeping the pod in `Init` state until credentials are ready.

## Test plan

- [ ] Deploy with `autoProvision=true` (default): GEA pod enters `Init:0/1` state immediately
- [ ] Controller reconciles and writes `losant-gea-credentials` secret
- [ ] Within ~30s the init container exits and GEA pod reaches `Running/1/1 Ready`
- [ ] No manual pod deletion was required
- [ ] `helm template .` renders the init container in the GEA Deployment

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)