### PR TITLE
fix(provisioner): create credential placeholder on first reconcile to prevent CreateContainerConfigError

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -85,13 +85,18 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 
-	// First reconcile: set phase to Provisioning.
+	// First reconcile: set phase to Provisioning and create credential placeholder.
 	if ls.Status.Phase == "" {
 		logger.Info("first reconcile, setting phase to Provisioning", "name", ls.Name)
 		ls.Status.Phase = losantv1alpha1.PhaseProvisioning
 		ls.Status.NextScheduledTime = &metav1.Time{Time: time.Now()}
 		if err := r.Status().Update(ctx, &ls); err != nil {
 			return ctrl.Result{}, err
+		}
+		// Create an empty Secret so the GEA pod can start before provisioning completes.
+		// Non-fatal: bootstrap will create it during provisioning if this fails.
+		if err := provisioner.EnsureCredentialPlaceholder(ctx, r.Client, ls.Spec.ProvisioningSecretRef.Namespace); err != nil {
+			logger.Error(err, "failed to ensure GEA credential placeholder")
 		}
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}

--- a/internal/provisioner/bootstrap.go
+++ b/internal/provisioner/bootstrap.go
@@ -35,6 +35,36 @@ import (
 
 const geaCredentialsSecretName = "losant-gea-credentials"
 
+// EnsureCredentialPlaceholder creates the losant-gea-credentials Secret with empty values
+// if it does not already exist. This allows the GEA pod to start (avoiding
+// CreateContainerConfigError) before real credentials are provisioned by Bootstrap.
+// It is idempotent and makes no Losant API calls.
+func EnsureCredentialPlaceholder(ctx context.Context, c client.Client, ns string) error {
+	var existing corev1.Secret
+	err := c.Get(ctx, types.NamespacedName{Name: geaCredentialsSecretName, Namespace: ns}, &existing)
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("read %s/%s: %w", ns, geaCredentialsSecretName, err)
+	}
+	placeholder := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      geaCredentialsSecretName,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{
+			"DEVICE_ID":     []byte(""),
+			"ACCESS_KEY":    []byte(""),
+			"ACCESS_SECRET": []byte(""),
+		},
+	}
+	if createErr := c.Create(ctx, placeholder); createErr != nil && !errors.IsAlreadyExists(createErr) {
+		return fmt.Errorf("create placeholder %s/%s: %w", ns, geaCredentialsSecretName, createErr)
+	}
+	return nil
+}
+
 // GEABootstrapper provisions initial GEA MQTT credentials into a cluster Secret.
 type GEABootstrapper struct {
 	Client       client.Client


### PR DESCRIPTION
## Summary
- Adds `EnsureCredentialPlaceholder` to `internal/provisioner/bootstrap.go` — creates `losant-gea-credentials` with empty values if absent (no Losant API calls)
- Calls it in the controller's first-reconcile block (before any Losant API calls) so the placeholder exists within ~1 second of LosantSync creation
- Non-fatal: if placeholder creation fails, logs an error and continues; `Bootstrap` will create the Secret during provisioning anyway

## Root cause
The GEA Deployment starts immediately but references `losant-gea-credentials` for its env vars. The Secret is only created in step 4.5 (after device provisioning), leaving a window where the pod is permanently stuck in `CreateContainerConfigError`. Kubernetes does not auto-retry `CreateContainerConfigError` pods when the referenced Secret appears.

## Fix flow
1. LosantSync created → first reconcile → placeholder Secret created with empty values
2. GEA pod starts successfully (empty creds, can't authenticate yet, but no crash loop)
3. Controller continues provisioning → step 4.5 runs `Bootstrap` → replaces empty values with real credentials
4. If `DeploymentRef` is set, rolling restart picks up real credentials

## Test plan
- [ ] `make test` passes (73.3% provisioner coverage, 88.5% controller coverage)
- [ ] On fresh deploy: `kubectl get secret losant-gea-credentials` exists within 1–2 seconds of applying the LosantSync CR
- [ ] GEA pod does not enter `CreateContainerConfigError`

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)