### PR TITLE
fix(helm): pin controller image tag; align GEA secret name with controller

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -46,6 +46,8 @@ GEA credentials secret name
 {{- define "losant-device.geaSecretName" -}}
 {{- if .Values.gea.credentials.existingSecret }}
 {{- .Values.gea.credentials.existingSecret }}
+{{- else if .Values.gea.autoProvision }}
+{{- "losant-gea-credentials" }}
 {{- else }}
 {{- include "losant-device.fullname" . }}-gea-credentials
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 controller:
   image:
     repository: ghcr.io/mak3r/losant-device
-    tag: latest
+    tag: v0.1.0-alpha.7
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources:


### PR DESCRIPTION
## Summary

**Fixes #241 — controller ImagePullBackOff on fresh install:**
- Changed `controller.image.tag` default from `latest` to `v0.1.0-alpha.7`
- The release pipeline only publishes versioned tags; `ghcr.io/mak3r/losant-device:latest` does not exist

**Fixes #242 — GEA pod never leaves `Init:0/1` / secret name mismatch:**
- Updated `geaSecretName` helper to return `losant-gea-credentials` when `gea.autoProvision=true`
- The controller's provisioner hardcodes this name; the previous Helm-computed name `losant-device-gea-credentials` never appeared in the init container's optional volume mount, so the pod polled indefinitely

### `geaSecretName` resolution table

| Condition | Secret name |
|---|---|
| `existingSecret` set | value of `existingSecret` |
| `autoProvision=true` (default) | `losant-gea-credentials` |
| `autoProvision=false` | `<fullname>-gea-credentials` |

## Test plan

- [ ] `helm install` with default values: controller pod reaches `READY 1/1` (not `ImagePullBackOff`)
- [ ] After controller reconcile writes `losant-gea-credentials`, GEA init container exits and pod reaches `Running`
- [ ] `helm template . --set gea.autoProvision=false` renders GEA with secret `losant-device-gea-credentials`
- [ ] `helm template . --set gea.credentials.existingSecret=my-secret` renders GEA with `my-secret`

Closes #241
Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)