### PR TITLE
fix(helm): use stable resource names matching kustomize scaffold

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "losant-device.fullname" . }}-controller
+  name: losant-device-controller-manager
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "losant-device.labels" . | nindent 4 }}

--- a/helm/templates/gea-deployment.yaml
+++ b/helm/templates/gea-deployment.yaml
@@ -10,11 +10,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "losant-device.fullname" . }}-gea
+      app: losant-gea
   template:
     metadata:
       labels:
-        app: {{ include "losant-device.fullname" . }}-gea
+        app: losant-gea
     spec:
       serviceAccountName: {{ include "losant-device.fullname" . }}-gea
       initContainers:

--- a/helm/templates/gea-service.yaml
+++ b/helm/templates/gea-service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: {{ include "losant-device.fullname" . }}-gea
+    app: losant-gea
   ports:
     - name: http-trigger
       port: {{ .Values.gea.service.port }}


### PR DESCRIPTION
## Summary

- **Controller Deployment**: renamed from `{{ fullname }}-controller` → `losant-device-controller-manager`, matching the kustomize scaffold name that `docs/setup/3-deploy.md` references
- **GEA pod label**: changed `app: {{ fullname }}-gea` → `app: losant-gea` (stable, release-name-independent) in both the Deployment's `selector.matchLabels` and `template.metadata.labels`
- **GEA Service selector**: updated from `{{ fullname }}-gea` → `losant-gea` to match the new pod label

The GEA Deployment `metadata.name` and `serviceAccountName` still use `{{ fullname }}-gea` (internal references only, not user-facing).

## Test plan

- [ ] `kubectl get deploy -n losant-system losant-device-controller-manager` returns the controller deployment
- [ ] `kubectl get pod -n losant-system -l app=losant-gea` returns the GEA pod
- [ ] GEA Service still correctly routes to GEA pod (selector matches label)
- [ ] `helm template .` renders consistent names across all three templates

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)