### PR TITLE
docs: fix GEA deployment name in kubectl commands

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -337,7 +337,7 @@ kubectl get secret losant-gea-credentials -n losant-system \
    ```
 5. Restart the GEA pod to pick up the updated secret:
    ```bash
-   kubectl rollout restart deployment/losant-gea -n losant-system
+   kubectl rollout restart deployment/losant-device-gea -n losant-system
    ```
 
 See [docs/setup/A-manual-provisioning.md](setup/A-manual-provisioning.md) for the full manual credential walkthrough.

--- a/docs/setup/4-losant-workflow.md
+++ b/docs/setup/4-losant-workflow.md
@@ -18,7 +18,7 @@ Before creating the workflow, confirm the device is present and Online:
 
 > If the device is not yet Online when you deploy the workflow, the deployment will fail with: *"Some of your selected devices have an agent version lower than the target version for this deployment."* Wait for the GEA pod to finish its MQTT handshake:
 > ```bash
-> kubectl logs deploy/losant-gea -n losant-system | grep "Connected to"
+> kubectl logs deploy/losant-device-gea -n losant-system | grep "Connected to"
 > ```
 > Then retry the deployment.
 

--- a/docs/setup/5-verify.md
+++ b/docs/setup/5-verify.md
@@ -23,7 +23,7 @@ Each condition has a `reason` and `message` that identifies exactly which step f
 ## Confirm GEA is connected
 
 ```bash
-kubectl logs deploy/losant-gea -n losant-system | grep "Connected to"
+kubectl logs deploy/losant-device-gea -n losant-system | grep "Connected to"
 # Expected: Connected to: mqtts://broker.losant.com
 ```
 

--- a/docs/setup/A-manual-provisioning.md
+++ b/docs/setup/A-manual-provisioning.md
@@ -100,7 +100,7 @@ If the access key is rotated or the device is recreated:
    ```
 3. Restart the GEA pod:
    ```bash
-   kubectl rollout restart deployment/losant-gea -n losant-system
+   kubectl rollout restart deployment/losant-device-gea -n losant-system
    ```
 
 See [docs/runbook.md](../runbook.md#gea-access-keysecret-rejected) for diagnosing connection failures.


### PR DESCRIPTION
## Summary

- Fixes 4 stale `deploy/losant-gea` references across the docs — the Helm chart deployment name resolves to `losant-device-gea` (fullname helper + `-gea`), not `losant-gea`
- Files updated: `docs/setup/4-losant-workflow.md`, `docs/setup/5-verify.md`, `docs/setup/A-manual-provisioning.md`, `docs/runbook.md`
- Pod-selector commands using `app=losant-gea` (the stable label from #245) are already correct and unchanged

Closes #246

## Test plan
- [ ] No remaining `deploy/losant-gea` or `deployment/losant-gea` in docs
- [ ] All four updated commands now reference `losant-device-gea`

🤖 Generated with [Claude Code](https://claude.com/claude-code)