### PR TITLE
docs(setup): add CRD installation step before helm install

### DIFF
--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -9,6 +9,32 @@ Install the losant-device operator and GEA with Helm, then apply the LosantSync 
 
 ---
 
+## Install the LosantSync CRD
+
+> **Required before `helm install`** — The Helm chart does not yet bundle the CRD ([#248](https://github.com/mak3r/losant-device/issues/248)). The `LosantSync` CRD must exist in the cluster before the controller starts, or the controller will crash with `no matches for kind "LosantSync"`.
+
+**Option A — from the repository:**
+
+```bash
+make install
+```
+
+**Option B — directly from the manifests:**
+
+```bash
+kubectl apply -f config/crd/bases/
+```
+
+Verify the CRD is registered before proceeding:
+
+```bash
+kubectl get crd losantsyncs.losant.io
+```
+
+> This step will be removed once [#248](https://github.com/mak3r/losant-device/issues/248) is resolved and the Helm chart bundles the CRD automatically.
+
+---
+
 ## Install with Helm
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a dedicated "Install the LosantSync CRD" section in `docs/setup/3-deploy.md` before the `helm install` step
- Provides two options: `make install` (from repo) and `kubectl apply -f config/crd/bases/` (direct)
- Includes a verification command (`kubectl get crd losantsyncs.losant.io`) and a note that this step is temporary pending #248

## Test plan
- [ ] Verify the new section appears before the `## Install with Helm` heading in rendered docs
- [ ] Confirm both install options are syntactically correct
- [ ] Confirm the section references issue #248 with correct link

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)