### PR TITLE
docs(setup): remove CRD pre-install workaround from 3-deploy.md

### DIFF
--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -9,32 +9,6 @@ Install the losant-device operator and GEA with Helm, then apply the LosantSync 
 
 ---
 
-## Install the LosantSync CRD
-
-> **Required before `helm install`** — The Helm chart does not yet bundle the CRD ([#248](https://github.com/mak3r/losant-device/issues/248)). The `LosantSync` CRD must exist in the cluster before the controller starts, or the controller will crash with `no matches for kind "LosantSync"`.
-
-**Option A — from the repository:**
-
-```bash
-make install
-```
-
-**Option B — directly from the manifests:**
-
-```bash
-kubectl apply -f config/crd/bases/
-```
-
-Verify the CRD is registered before proceeding:
-
-```bash
-kubectl get crd losantsyncs.losant.io
-```
-
-> This step will be removed once [#248](https://github.com/mak3r/losant-device/issues/248) is resolved and the Helm chart bundles the CRD automatically.
-
----
-
 ## Install with Helm
 
 ```bash


### PR DESCRIPTION
## Summary

- Removes the `## Install the LosantSync CRD` section and its trailing `---` separator from `docs/setup/3-deploy.md`
- The Helm chart now bundles the CRD via `helm/templates/crd.yaml` (PR #252, resolves #248), so the manual pre-install step is obsolete
- `## Install with Helm` is now the first section after the Prerequisites block

## Test plan

- [ ] Verify `## Install with Helm` is the first H2 section after Prerequisites in the rendered doc
- [ ] Confirm no references to the removed workaround remain in the file

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)