### PR TITLE
fix(provisioner): use Update not Patch to write losant-gea-credentials Secret

### DIFF
--- a/internal/provisioner/bootstrap.go
+++ b/internal/provisioner/bootstrap.go
@@ -117,8 +117,8 @@ func (b *GEABootstrapper) Bootstrap(ctx context.Context, ls *losantv1alpha1.Losa
 	} else {
 		patched := existing.DeepCopy()
 		patched.Data = data
-		if err := b.Client.Patch(ctx, patched, client.MergeFrom(&existing)); err != nil {
-			return fmt.Errorf("patch %s/%s: %w", ns, geaCredentialsSecretName, err)
+		if err := b.Client.Update(ctx, patched); err != nil {
+			return fmt.Errorf("update %s/%s: %w", ns, geaCredentialsSecretName, err)
 		}
 	}
 

--- a/internal/provisioner/bootstrap_test.go
+++ b/internal/provisioner/bootstrap_test.go
@@ -206,20 +206,20 @@ func TestBootstrap_SecretCreateFails(t *testing.T) {
 	}
 }
 
-// TestBootstrap_SecretPatchFails verifies that a k8s Patch failure on an incomplete secret is propagated.
-func TestBootstrap_SecretPatchFails(t *testing.T) {
-	patchErr := errors.New("patch rejected")
+// TestBootstrap_SecretUpdateFails verifies that a k8s Update failure on an incomplete secret is propagated.
+func TestBootstrap_SecretUpdateFails(t *testing.T) {
+	updateErr := errors.New("update rejected")
 	incomplete := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: geaSecretName, Namespace: testNS},
 		Data:       map[string][]byte{"DEVICE_ID": []byte("old")},
 	}
 
 	c := buildFakeClientWithInterceptor(interceptor.Funcs{
-		Patch: func(_ context.Context, cl client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+		Update: func(_ context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
 			if _, ok := obj.(*corev1.Secret); ok {
-				return patchErr
+				return updateErr
 			}
-			return cl.Patch(context.Background(), obj, patch, opts...)
+			return cl.Update(context.Background(), obj, opts...)
 		},
 	}, incomplete)
 
@@ -229,8 +229,8 @@ func TestBootstrap_SecretPatchFails(t *testing.T) {
 	}
 
 	err := b.Bootstrap(context.Background(), baseLS(), "device-x")
-	if !errors.Is(err, patchErr) {
-		t.Errorf("expected patch error, got: %v", err)
+	if !errors.Is(err, updateErr) {
+		t.Errorf("expected update error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Changes `Bootstrap` to use `client.Update` (RBAC verb: `update`) instead of `client.Patch` (verb: `patch`) when overwriting an incomplete `losant-gea-credentials` Secret — the only approved verb in `config/rbac/role.yaml` is `update`
- Updates `TestBootstrap_SecretPatchFails` → `TestBootstrap_SecretUpdateFails` to intercept `Update` and match the corrected code path

## Test plan
- [x] `make test` passes
- [x] `TestBootstrap_SecretUpdateFails` covers the Update-failure path
- [x] All provisioner and controller tests green

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)