### PR TITLE
fix(helm): sync ClusterRole permissions for secrets and deployments

### DIFF
--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -22,10 +22,19 @@ rules:
   - nodes
   - persistentvolumeclaims
   - pods
-  - secrets
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
   - watch
 - apiGroups:
   - apps
@@ -34,6 +43,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - coordination.k8s.io


### PR DESCRIPTION
## Summary

- Separates `secrets` into its own ClusterRole rule with `create`, `get`, `list`, `update`, `watch` so the controller can create/update the `losant-gea-credentials` Secret during Bootstrap
- Adds `patch` to the `deployments` rule so `restartDeployment` can patch the GEA Deployment
- Nodes/pvcs/pods remain read-only (no change)

## Test plan

- [ ] `helm install` followed by `kubectl apply losantsync.yaml` creates `losant-gea-credentials` on first Bootstrap
- [ ] Bootstrap can update the Secret without a permissions error
- [ ] `restartDeployment` successfully patches the GEA Deployment when `spec.gea.deploymentRef` is set
- [ ] GEA pod transitions to Running and LosantSync phase reaches Active

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)