### PR TITLE
release: v0.1.0-alpha.9

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 images:
 - name: controller
   newName: ghcr.io/mak3r/losant-device
-  newTag: v0.1.0-alpha.8
+  newTag: v0.1.0-alpha.9

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -3,7 +3,7 @@ name: losant-device
 description: Kubernetes operator that monitors cluster health and reports metrics to the Losant IoT platform
 type: application
 version: 0.1.0
-appVersion: v0.1.0-alpha.8
+appVersion: v0.1.0-alpha.9
 keywords:
   - losant
   - iot

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,7 +1,7 @@
 controller:
   image:
     repository: ghcr.io/mak3r/losant-device
-    tag: v0.1.0-alpha.8
+    tag: v0.1.0-alpha.9
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources:

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -173,11 +173,15 @@ func (c *HTTPClient) GetDevice(ctx context.Context, applicationID, deviceID stri
 	return &dev, nil
 }
 
-// CreateDeviceAccessKey creates a Losant access key for the given device and returns
+// CreateDeviceAccessKey creates a Losant access key scoped to deviceID and returns
 // the keyID, key, and secret. The secret is shown only in this response.
 func (c *HTTPClient) CreateDeviceAccessKey(ctx context.Context, applicationID, deviceID, name string) (string, string, string, error) {
-	payload := map[string]string{"name": name}
-	path := fmt.Sprintf("%s/applications/%s/devices/%s/accessKeys", apiBase, applicationID, deviceID)
+	payload := map[string]interface{}{
+		"description": name,
+		"deviceIds":   []string{deviceID},
+		"filterType":  "specific",
+	}
+	path := fmt.Sprintf("%s/applications/%s/keys", apiBase, applicationID)
 	body, err := c.doRequest(ctx, http.MethodPost, path, payload)
 	if err != nil {
 		return "", "", "", err

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -401,6 +401,100 @@ func TestFindDeviceByName_InvalidJSON(t *testing.T) {
 	}
 }
 
+// --- CreateDeviceAccessKey ---
+
+// TestCreateDeviceAccessKey_VerifiesPostToKeysEndpoint asserts that the corrected
+// client sends POST to /applications/{appId}/keys (not the old device-scoped path
+// that returned 405) and includes deviceIds + filterType in the body.
+func TestCreateDeviceAccessKey_VerifiesPostToKeysEndpoint(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/applications/app-123/keys", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		writeJSON(w, map[string]interface{}{
+			"keyId":  "kid-1",
+			"key":    "k1",
+			"secret": "s1",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, _, _, err := newTestHTTPClient(srv.URL).CreateDeviceAccessKey(context.Background(), "app-123", "dev-xyz", "my-key"); err != nil {
+		t.Fatalf("CreateDeviceAccessKey: unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("HTTP method: got %q, want POST", gotMethod)
+	}
+	if gotPath != "/applications/app-123/keys" {
+		t.Errorf("path: got %q, want /applications/app-123/keys", gotPath)
+	}
+	deviceIDs, _ := gotBody["deviceIds"].([]interface{})
+	if len(deviceIDs) != 1 || deviceIDs[0] != "dev-xyz" {
+		t.Errorf("deviceIds: got %v, want [dev-xyz]", deviceIDs)
+	}
+	if gotBody["filterType"] != "specific" {
+		t.Errorf("filterType: got %v, want \"specific\"", gotBody["filterType"])
+	}
+}
+
+func TestCreateDeviceAccessKey_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /applications/app-123/keys", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]interface{}{
+			"keyId":  "key-id-42",
+			"key":    "access-key-value",
+			"secret": "access-secret-value",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	keyID, key, secret, err := newTestHTTPClient(srv.URL).CreateDeviceAccessKey(context.Background(), "app-123", "dev-abc", "controller-key")
+	if err != nil {
+		t.Fatalf("CreateDeviceAccessKey: unexpected error: %v", err)
+	}
+	if keyID != "key-id-42" {
+		t.Errorf("keyID: got %q, want %q", keyID, "key-id-42")
+	}
+	if key != "access-key-value" {
+		t.Errorf("key: got %q, want %q", key, "access-key-value")
+	}
+	if secret != "access-secret-value" {
+		t.Errorf("secret: got %q, want %q", secret, "access-secret-value")
+	}
+}
+
+// TestCreateDeviceAccessKey_Non2xxError verifies that a non-2xx response surfaces as an error.
+func TestCreateDeviceAccessKey_Non2xxError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"type":"MethodNotAllowed","message":"POST is not allowed"}`, http.StatusMethodNotAllowed)
+	}))
+	defer srv.Close()
+
+	_, _, _, err := newTestHTTPClient(srv.URL).CreateDeviceAccessKey(context.Background(), "app-123", "dev-xyz", "k")
+	if err == nil {
+		t.Fatal("expected error on 405 response, got nil")
+	}
+}
+
+func TestCreateDeviceAccessKey_EmptyKeyInResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /applications/app-123/keys", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]interface{}{"keyId": "kid", "key": "", "secret": ""})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	_, _, _, err := newTestHTTPClient(srv.URL).CreateDeviceAccessKey(context.Background(), "app-123", "dev-abc", "k")
+	if err == nil {
+		t.Fatal("expected error when key/secret are empty in response, got nil")
+	}
+}
+
 // --- GetDevice: invalid JSON response ---
 
 func TestGetDevice_InvalidJSON(t *testing.T) {

--- a/internal/provisioner/bootstrap_test.go
+++ b/internal/provisioner/bootstrap_test.go
@@ -262,6 +262,36 @@ func TestBootstrap_DeploymentRestart(t *testing.T) {
 	}
 }
 
+// TestBootstrap_PassesCorrectArgsToCreateAccessKey verifies that Bootstrap
+// forwards the spec's ApplicationID and the provided clusterDeviceID to
+// CreateDeviceAccessKey — regression guard for the #268 405 issue where the
+// wrong arguments could cause an invalid API path or method.
+func TestBootstrap_PassesCorrectArgsToCreateAccessKey(t *testing.T) {
+	mc := losant.NewMockClient()
+	b := &provisioner.GEABootstrapper{
+		Client:       buildFakeClient(),
+		LosantClient: mc,
+	}
+
+	ls := baseLS()
+	ls.Spec.ApplicationID = "app-regression"
+
+	if err := b.Bootstrap(context.Background(), ls, "device-regression"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mc.CreateDeviceAccessKeyCalls) != 1 {
+		t.Fatalf("expected 1 CreateDeviceAccessKey call, got %d", len(mc.CreateDeviceAccessKeyCalls))
+	}
+	call := mc.CreateDeviceAccessKeyCalls[0]
+	if call.ApplicationID != "app-regression" {
+		t.Errorf("ApplicationID: got %q, want %q", call.ApplicationID, "app-regression")
+	}
+	if call.DeviceID != "device-regression" {
+		t.Errorf("DeviceID: got %q, want %q", call.DeviceID, "device-regression")
+	}
+}
+
 // TestBootstrap_DeploymentNotFound verifies that a missing GEA Deployment returns an error.
 func TestBootstrap_DeploymentNotFound(t *testing.T) {
 	mc := losant.NewMockClient()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.8"
+const Version = "v0.1.0-alpha.9"


### PR DESCRIPTION
## Summary

Ships the Losant access key API fix that caused GEA credentials to never be written on fresh deployments.

### Bug Fixes

- **fix(losant):** use `POST /applications/{id}/keys` to create device access key ([#271](https://github.com/mak3r/losant-device/pull/271), closes [#268](https://github.com/mak3r/losant-device/issues/268))
  The previous path `/applications/{appId}/devices/{deviceId}/accessKeys` does not exist in the Losant REST API and returned 405 Method Not Allowed. Corrected to `POST /applications/{applicationId}/keys` with `deviceIds` and `filterType: "specific"` in the request body to scope the key to the cluster device.

### Tests

- **test(losant,provisioner):** add coverage for `CreateDeviceAccessKey` HTTP method, path, and error paths ([#270](https://github.com/mak3r/losant-device/pull/270), [#271](https://github.com/mak3r/losant-device/pull/271))
  Regression guards: verifies correct POST method, `/applications/{id}/keys` path, `deviceIds`/`filterType` body fields, 405 error surfacing, empty-key validation, and correct argument forwarding from Bootstrap.

### Version bumps

- `internal/version/version.go` → `v0.1.0-alpha.9`
- `helm/Chart.yaml` (appVersion) → `v0.1.0-alpha.9`
- `helm/values.yaml` (controller.image.tag) → `v0.1.0-alpha.9`
- `config/manager/kustomization.yaml` (newTag) → `v0.1.0-alpha.9`

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, push tag `v0.1.0-alpha.9` to trigger `release.yml`
- [ ] Verify `ghcr.io/mak3r/losant-device:v0.1.0-alpha.9` image published

🤖 Generated with [Claude Code](https://claude.com/claude-code)