### PR TITLE
chore(release): v0.1.0-alpha.10 patch release

### DIFF
--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -179,7 +179,7 @@ func (c *HTTPClient) CreateDeviceAccessKey(ctx context.Context, applicationID, d
 	payload := map[string]interface{}{
 		"description": name,
 		"deviceIds":   []string{deviceID},
-		"filterType":  "specific",
+		"filterType":  "whitelist",
 	}
 	path := fmt.Sprintf("%s/applications/%s/keys", apiBase, applicationID)
 	body, err := c.doRequest(ctx, http.MethodPost, path, payload)

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -436,8 +436,8 @@ func TestCreateDeviceAccessKey_VerifiesPostToKeysEndpoint(t *testing.T) {
 	if len(deviceIDs) != 1 || deviceIDs[0] != "dev-xyz" {
 		t.Errorf("deviceIds: got %v, want [dev-xyz]", deviceIDs)
 	}
-	if gotBody["filterType"] != "specific" {
-		t.Errorf("filterType: got %v, want \"specific\"", gotBody["filterType"])
+	if gotBody["filterType"] != "whitelist" {
+		t.Errorf("filterType: got %v, want \"whitelist\"", gotBody["filterType"])
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.9"
+const Version = "v0.1.0-alpha.10"


### PR DESCRIPTION
## Summary

- Fixes filterType regression (#274): `CreateDeviceAccessKey` now sends `"filterType": "whitelist"` instead of the invalid value `"specific"`
- Fixes test assertion (#275): `TestCreateDeviceAccessKey` now asserts the correct `"whitelist"` value
- Bumps version to `v0.1.0-alpha.10`

## Changes from develop
- `6a60480` fix(losant): use whitelist filterType when creating device access key (#277)
- `aa9a25d` fix(test): correct filterType assertion from "specific" to "whitelist"
- `ef6d0f3` fix(losant): use whitelist filterType when creating device access key
- `bd16fd3` chore(release): bump version to v0.1.0-alpha.10

## Closes
Closes #278

## Test plan
- [x] #274 merged to develop
- [x] #275 merged to develop
- [x] CI green on release branch
- [ ] PR merged to main
- [ ] Tag v0.1.0-alpha.10 and GitHub Release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)