### PR TITLE
fix(helm): add missing GEA ServiceAccount template

### DIFF
--- a/helm/templates/serviceaccount-gea.yaml
+++ b/helm/templates/serviceaccount-gea.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "losant-device.fullname" . }}-gea
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gea
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Adds `helm/templates/serviceaccount-gea.yaml` to create the `losant-device-gea` ServiceAccount that `gea-deployment.yaml` references
- Follows the same pattern as the controller ServiceAccount: gated on `serviceAccount.create`, uses shared `losant-device.labels` and optional annotations
- Validated with `helm template` — both `losant-device-gea` and `losant-device-controller` ServiceAccounts render correctly

## Test plan
- [ ] `helm template losant-device helm/ --namespace losant-system` renders a `ServiceAccount` named `losant-device-gea`
- [ ] `helm install` on a fresh cluster creates the GEA SA before the GEA Deployment so the pod starts successfully
- [ ] GEA pod reaches Running state; LosantSync does not enter `GEAUnreachable`

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)