### PR TITLE
fix(docs): correct helm --set path for controller image tag

### DIFF
--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -26,7 +26,7 @@ This deploys:
 > helm install losant-device helm/ \
 >   --namespace losant-system \
 >   --create-namespace \
->   --set image.tag=v0.1.0-alpha.4
+>   --set controller.image.tag=v0.1.0-alpha.4
 > ```
 
 ---


### PR DESCRIPTION
## Summary
- Fixes `--set image.tag=<version>` → `--set controller.image.tag=<version>` in the helm install example in `docs/setup/3-deploy.md`
- Using the wrong path silently falls back to the default tag in `values.yaml`, causing users to unknowingly run the wrong image version

## Test plan
- [ ] Verify `grep 'controller.image.tag' docs/setup/3-deploy.md` returns the corrected line

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)