### PR TITLE
chore(release): v0.1.0-alpha.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - run: make test
       - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:${{ github.ref_name }}
+      - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:latest
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
       - run: make test
       - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:${{ github.ref_name }}
       - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:latest
+      - name: Verify multi-arch manifest
+        run: |
+          MANIFEST=$(docker buildx imagetools inspect ghcr.io/mak3r/losant-device:${{ github.ref_name }})
+          echo "## Multi-arch manifest: ghcr.io/mak3r/losant-device:${{ github.ref_name }}" >> "$GITHUB_STEP_SUMMARY"
+          printf '```\n%s\n```\n' "$MANIFEST" >> "$GITHUB_STEP_SUMMARY"
+          echo "$MANIFEST" | grep -q "linux/amd64" || { echo "ERROR: linux/amd64 digest missing from manifest"; exit 1; }
+          echo "$MANIFEST" | grep -q "linux/arm64" || { echo "ERROR: linux/arm64 digest missing from manifest"; exit 1; }
+          echo "Verified: linux/amd64 and linux/arm64 both present."
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/helm/templates/serviceaccount-gea.yaml
+++ b/helm/templates/serviceaccount-gea.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "losant-device.fullname" . }}-gea
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gea
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -16,4 +16,4 @@ limitations under the License.
 
 package version
 
-const Version = "v0.1.0-alpha.9"
+const Version = "v0.1.0-alpha.11"


### PR DESCRIPTION
## Release v0.1.0-alpha.11

Promotes `develop` to `main` for the v0.1.0-alpha.11 release.

### Changes since v0.1.0-alpha.10

- fix(helm): add missing GEA ServiceAccount template (#283) — `losant-device-gea` SA was missing, causing GEA pod to fail on fresh installs
- ci(release): verify multi-arch manifest before publishing GitHub Release (#279)
- ci(release): also push :latest tag on every release

### Version bump

`internal/version/version.go`: `v0.1.0-alpha.9` → `v0.1.0-alpha.11`

(develop was at alpha.9; alpha.10 was a patch release that went directly to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)