### PR TITLE
feat(losant): full device lifecycle — attributes, self-healing, and finalizer

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -31,6 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -71,6 +72,16 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Deletion: run device cleanup before removing finalizer.
+	if !ls.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, &ls)
+	}
+
+	// Add finalizer on first non-deleted reconcile; requeue to confirm write.
+	if controllerutil.AddFinalizer(&ls, "losant.io/device-cleanup") {
+		return ctrl.Result{}, r.Update(ctx, &ls)
 	}
 
 	// Suspend: halt all reconciliation.
@@ -149,6 +160,10 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		logger.Error(err, "failed to ensure cluster device")
 		return r.setDegraded(ctx, &ls, "DevicesProvisioned", "ClusterDeviceError", err.Error())
 	}
+	if ls.Status.ClusterDeviceID != "" && ls.Status.ClusterDeviceID != clusterDeviceID {
+		logger.Info("cluster identity changed: old device is now orphaned in Losant; update clusterName is effectively a destructive operation",
+			"oldDeviceID", ls.Status.ClusterDeviceID, "newDeviceID", clusterDeviceID)
+	}
 	ls.Status.ClusterDeviceID = clusterDeviceID
 
 	// Step 4.5: one-time GEA credential bootstrap (idempotent; skipped once GEABootstrapped=True).
@@ -224,6 +239,49 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	logger.Info("sync complete", "name", ls.Name, "nextSync", next.Round(time.Second))
 	return ctrl.Result{RequeueAfter: time.Until(next)}, nil
+}
+
+// handleDeletion deletes all Losant devices registered by this CR, then removes the finalizer.
+func (r *LosantSyncReconciler) handleDeletion(ctx context.Context, ls *losantv1alpha1.LosantSync) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(ls, "losant.io/device-cleanup") {
+		return ctrl.Result{}, nil
+	}
+
+	var secret corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      ls.Spec.ProvisioningSecretRef.Name,
+		Namespace: ls.Spec.ProvisioningSecretRef.Namespace,
+	}, &secret); err != nil {
+		return ctrl.Result{}, fmt.Errorf("deletion: read provisioning secret: %w", err)
+	}
+
+	lc := r.LosantClient
+	if lc == nil {
+		var err error
+		lc, err = losant.NewHTTPClient(&secret, ls.Spec.ApplicationID)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("deletion: construct losant client: %w", err)
+		}
+	}
+
+	for nodeName, nodeDeviceID := range ls.Status.NodeDevices {
+		if err := lc.DeleteDevice(ctx, ls.Spec.ApplicationID, nodeDeviceID); err != nil {
+			logger.Error(err, "failed to delete node device", "node", nodeName, "deviceID", nodeDeviceID)
+			return ctrl.Result{}, err
+		}
+	}
+
+	if ls.Status.ClusterDeviceID != "" {
+		if err := lc.DeleteDevice(ctx, ls.Spec.ApplicationID, ls.Status.ClusterDeviceID); err != nil {
+			logger.Error(err, "failed to delete cluster device", "deviceID", ls.Status.ClusterDeviceID)
+			return ctrl.Result{}, err
+		}
+	}
+
+	controllerutil.RemoveFinalizer(ls, "losant.io/device-cleanup")
+	return ctrl.Result{}, r.Update(ctx, ls)
 }
 
 // SetupWithManager registers the controller with the manager.
@@ -329,5 +387,7 @@ func nodeAttributes(h monitor.NodeHealth) map[string]interface{} {
 		"pod_count":       h.PodCount,
 		"not_ready_pods":  h.NotReadyPods,
 		"crashloop_pods":  h.CrashLoopPods,
+		"cpu_request_pct": h.CPURequestPct,
+		"mem_request_pct": h.MemRequestPct,
 	}
 }

--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -539,6 +539,197 @@ func TestClientConstructionInvalidSecret(t *testing.T) {
 	}
 }
 
+// TestFinalizerAddedOnFirstReconcile verifies that a CR created without the
+// device-cleanup finalizer gets the finalizer added on the first reconcile.
+func TestFinalizerAddedOnFirstReconcile(t *testing.T) {
+	ls := baseLS("add-finalizer")
+	ls.Finalizers = nil // clear the pre-populated finalizer to exercise the add path
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, losant.NewMockClient(), gea.NewMockClient(), monitor.NewHealthStore())
+
+	if _, err := r.Reconcile(context.Background(), reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	var got losantv1alpha1.LosantSync
+	if err := c.Get(context.Background(), reqFor(ls.Name).NamespacedName, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	found := false
+	for _, f := range got.Finalizers {
+		if f == "losant.io/device-cleanup" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected losant.io/device-cleanup finalizer to be added on first reconcile")
+	}
+}
+
+// TestFinalizerNotDuplicatedIfPresent verifies that when the CR already has the
+// device-cleanup finalizer, Reconcile does not call r.Update (no metadata patch).
+func TestFinalizerNotDuplicatedIfPresent(t *testing.T) {
+	ls := baseLS("no-dup-finalizer") // already has finalizer via baseLS
+	var metaUpdateCalls int
+	c := buildClientWithInterceptor(interceptor.Funcs{
+		Update: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*losantv1alpha1.LosantSync); ok {
+				metaUpdateCalls++
+			}
+			return cl.Update(ctx, obj, opts...)
+		},
+	}, ls, credsSecret())
+	r := newReconciler(c, losant.NewMockClient(), gea.NewMockClient(), monitor.NewHealthStore())
+
+	if _, err := r.Reconcile(context.Background(), reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	if metaUpdateCalls != 0 {
+		t.Errorf("r.Update called %d time(s), want 0 (finalizer already present, no metadata patch needed)", metaUpdateCalls)
+	}
+}
+
+// TestTeardownOnDeletion verifies that when a CR has a DeletionTimestamp set,
+// the reconciler calls DeleteDevice for each registered node and cluster device,
+// then removes the finalizer.
+func TestTeardownOnDeletion(t *testing.T) {
+	ls := baseLS("teardown")
+	ts := metav1.Now()
+	ls.DeletionTimestamp = &ts
+	ls.Status.ClusterDeviceID = "cluster-dev-id"
+	ls.Status.NodeDevices = map[string]string{
+		"node-1": "node-dev-1",
+		"node-2": "node-dev-2",
+	}
+	ml := losant.NewMockClient()
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, ml, gea.NewMockClient(), monitor.NewHealthStore())
+
+	if _, err := r.Reconcile(context.Background(), reqFor(ls.Name)); err != nil {
+		t.Fatalf("teardown reconcile: %v", err)
+	}
+	if len(ml.DeleteDeviceCalls) != 3 {
+		t.Errorf("DeleteDevice calls: got %d, want 3 (2 nodes + 1 cluster)", len(ml.DeleteDeviceCalls))
+	}
+	// After finalizer removal the object may be garbage-collected by the fake client.
+	var got losantv1alpha1.LosantSync
+	if c.Get(context.Background(), reqFor(ls.Name).NamespacedName, &got) == nil {
+		for _, f := range got.Finalizers {
+			if f == "losant.io/device-cleanup" {
+				t.Error("losant.io/device-cleanup finalizer should have been removed after teardown")
+			}
+		}
+	}
+}
+
+// TestTeardownWith404 verifies that when DeleteDevice returns nil (simulating a
+// 404-already-gone response), the teardown still completes and the finalizer is removed.
+func TestTeardownWith404(t *testing.T) {
+	ls := baseLS("teardown-404")
+	ts := metav1.Now()
+	ls.DeletionTimestamp = &ts
+	ls.Status.ClusterDeviceID = "gone-device-id"
+	ml := losant.NewMockClient()
+	ml.DeleteDeviceFunc = func(_ context.Context, _, _ string) error { return nil }
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, ml, gea.NewMockClient(), monitor.NewHealthStore())
+
+	if _, err := r.Reconcile(context.Background(), reqFor(ls.Name)); err != nil {
+		t.Fatalf("teardown reconcile: %v", err)
+	}
+	var got losantv1alpha1.LosantSync
+	if c.Get(context.Background(), reqFor(ls.Name).NamespacedName, &got) == nil {
+		for _, f := range got.Finalizers {
+			if f == "losant.io/device-cleanup" {
+				t.Error("finalizer should be removed even when device returns 404 (already gone)")
+			}
+		}
+	}
+}
+
+// TestTeardownRetryOnError verifies that when DeleteDevice returns a network error,
+// the finalizer is NOT removed and the reconciler surfaces the error for retry.
+func TestTeardownRetryOnError(t *testing.T) {
+	ls := baseLS("teardown-err")
+	ts := metav1.Now()
+	ls.DeletionTimestamp = &ts
+	ls.Status.ClusterDeviceID = "cluster-dev-id"
+	ml := losant.NewMockClient()
+	ml.DeleteDeviceFunc = func(_ context.Context, _, _ string) error {
+		return errors.New("connection refused")
+	}
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, ml, gea.NewMockClient(), monitor.NewHealthStore())
+
+	_, err := r.Reconcile(context.Background(), reqFor(ls.Name))
+	if err == nil {
+		t.Fatal("expected error when DeleteDevice fails, got nil")
+	}
+
+	var got losantv1alpha1.LosantSync
+	if err := c.Get(context.Background(), reqFor(ls.Name).NamespacedName, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	found := false
+	for _, f := range got.Finalizers {
+		if f == "losant.io/device-cleanup" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("losant.io/device-cleanup finalizer must remain after a failed teardown so the reconciler retries")
+	}
+}
+
+// TestClusterIdentityChange verifies that when EnsureClusterDevice returns a
+// different device ID than the one stored in Status, the reconciler updates
+// Status.ClusterDeviceID to the new value and still reaches Phase=Active.
+func TestClusterIdentityChange(t *testing.T) {
+	ls := baseLS("identity-change")
+	ls.Status.Phase = losantv1alpha1.PhaseProvisioning
+	ls.Status.ClusterDeviceID = "old-cluster-id"
+	ls.Status.NextScheduledTime = &metav1.Time{Time: time.Now().Add(-time.Second)}
+	ml := losant.NewMockClient()
+	ml.EnsureClusterDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec) (string, error) {
+		return "new-cluster-id", nil
+	}
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, ml, gea.NewMockClient(), monitor.NewHealthStore())
+
+	if _, err := r.Reconcile(context.Background(), reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	var got losantv1alpha1.LosantSync
+	if err := c.Get(context.Background(), reqFor(ls.Name).NamespacedName, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status.ClusterDeviceID != "new-cluster-id" {
+		t.Errorf("ClusterDeviceID: got %q, want %q", got.Status.ClusterDeviceID, "new-cluster-id")
+	}
+	if got.Status.Phase != losantv1alpha1.PhaseActive {
+		t.Errorf("Phase: got %q, want Active (reconcile should succeed despite identity change)", got.Status.Phase)
+	}
+}
+
+// TestNodeAttributesCPUAndMemRequestPct verifies that cpu_request_pct and
+// mem_request_pct from NodeHealth are included in the GEA ReportState payload.
+func TestNodeAttributesCPUAndMemRequestPct(t *testing.T) {
+	ls := baseLS("node-attrs-pct")
+	hs := monitor.NewHealthStore()
+	hs.Update(monitor.ClusterHealth{}, map[string]monitor.NodeHealth{
+		"node-1": {CPURequestPct: 0.75, MemRequestPct: 0.80},
+	})
+	mg := gea.NewMockClient()
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, losant.NewMockClient(), mg, hs)
+
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	mg.AssertPayloadContains(t, "mock-node-node-1", "cpu_request_pct", 0.75)
+	mg.AssertPayloadContains(t, "mock-node-node-1", "mem_request_pct", 0.80)
+}
+
 // conditionTrue reports whether a named condition has Status=True.
 func conditionTrue(conds []metav1.Condition, condType string) bool {
 	for _, c := range conds {

--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -48,7 +48,10 @@ var testScheme = func() *runtime.Scheme {
 
 func baseLS(name string) *losantv1alpha1.LosantSync {
 	return &losantv1alpha1.LosantSync{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Finalizers: []string{"losant.io/device-cleanup"},
+		},
 		Spec: losantv1alpha1.LosantSyncSpec{
 			ApplicationID: "app-123",
 			ClusterName:   "test-cluster",

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -67,6 +68,14 @@ type LosantClient interface {
 	// CreateDeviceAccessKey creates a new Losant access key for the given device.
 	// Returns keyID, key, and secret. The secret is only available in this response.
 	CreateDeviceAccessKey(ctx context.Context, applicationID, deviceID, name string) (keyID, key, secret string, err error)
+
+	// PatchDeviceAttributes adds missing attributes to an existing Losant device.
+	// Existing attributes are not removed. Idempotent.
+	PatchDeviceAttributes(ctx context.Context, applicationID, deviceID string, attrs []DeviceAttribute) error
+
+	// DeleteDevice removes a device from Losant.
+	// Returns nil if the device does not exist (404 treated as success).
+	DeleteDevice(ctx context.Context, applicationID, deviceID string) error
 }
 
 // Device is a minimal Losant device representation sufficient for the provisioning workflow.
@@ -80,6 +89,13 @@ type Device struct {
 type Tag struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+// DeviceAttribute declares one telemetry attribute on a Losant device.
+// DataType must be one of "number", "string", or "boolean".
+type DeviceAttribute struct {
+	Name     string `json:"name"`
+	DataType string `json:"dataType"`
 }
 
 // HTTPClient implements LosantClient using the Losant REST API.
@@ -117,32 +133,40 @@ func (c *HTTPClient) Ping(ctx context.Context) error {
 // EnsureClusterDevice looks up the cluster Edge Compute device by name and creates it if absent.
 func (c *HTTPClient) EnsureClusterDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec) (string, error) {
 	name := clusterDeviceName(spec.ClusterName)
+	attrs := clusterDeviceAttributes()
 	existing, err := c.findDeviceByName(ctx, spec.ApplicationID, name)
 	if err != nil {
 		return "", err
 	}
 	if existing != nil {
+		if err := c.PatchDeviceAttributes(ctx, spec.ApplicationID, existing.DeviceID, attrs); err != nil {
+			return "", err
+		}
 		return existing.DeviceID, nil
 	}
 
 	tags := tagsFromSpec(spec)
-	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, "", tags)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassEdge, spec.DeviceRecipeID, "", tags, attrs)
 }
 
 // EnsureNodeDevice looks up the peripheral device for a node by name and creates it if absent.
 func (c *HTTPClient) EnsureNodeDevice(ctx context.Context, spec losantv1alpha1.LosantSyncSpec, nodeName, gatewayID string) (string, error) {
 	name := nodeDeviceName(spec.ClusterName, nodeName)
+	attrs := nodeDeviceAttributes()
 	existing, err := c.findDeviceByName(ctx, spec.ApplicationID, name)
 	if err != nil {
 		return "", err
 	}
 	if existing != nil {
+		if err := c.PatchDeviceAttributes(ctx, spec.ApplicationID, existing.DeviceID, attrs); err != nil {
+			return "", err
+		}
 		return existing.DeviceID, nil
 	}
 
 	tags := tagsFromSpec(spec)
 	tags = append(tags, Tag{Key: "nodeName", Value: nodeName})
-	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, gatewayID, tags)
+	return c.createDevice(ctx, spec.ApplicationID, name, deviceClassNode, spec.DeviceRecipeID, gatewayID, tags, attrs)
 }
 
 // UpdateDeviceTags replaces the tags on the given device.
@@ -223,7 +247,7 @@ func (c *HTTPClient) findDeviceByName(ctx context.Context, applicationID, name s
 }
 
 // createDevice POSTs a new device and returns the assigned device ID.
-func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID, gatewayID string, tags []Tag) (string, error) {
+func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, class, recipeID, gatewayID string, tags []Tag, attrs []DeviceAttribute) (string, error) {
 	payload := map[string]interface{}{
 		"name":        name,
 		"deviceClass": class,
@@ -234,6 +258,9 @@ func (c *HTTPClient) createDevice(ctx context.Context, applicationID, name, clas
 	}
 	if gatewayID != "" {
 		payload["gatewayId"] = gatewayID
+	}
+	if len(attrs) > 0 {
+		payload["attributes"] = attrs
 	}
 
 	path := fmt.Sprintf("%s/applications/%s/devices", apiBase, applicationID)
@@ -286,6 +313,60 @@ func (c *HTTPClient) doRequest(ctx context.Context, method, path string, payload
 		return nil, fmt.Errorf("losant api %s %s: status %d: %s", method, path, resp.StatusCode, respBody)
 	}
 	return respBody, nil
+}
+
+// PatchDeviceAttributes adds missing attributes to an existing Losant device.
+func (c *HTTPClient) PatchDeviceAttributes(ctx context.Context, applicationID, deviceID string, attrs []DeviceAttribute) error {
+	payload := map[string]interface{}{"attributes": attrs}
+	path := fmt.Sprintf("%s/applications/%s/devices/%s", apiBase, applicationID, deviceID)
+	_, err := c.doRequest(ctx, http.MethodPatch, path, payload)
+	return err
+}
+
+// DeleteDevice removes a device from Losant. Returns nil on 404 (already gone).
+func (c *HTTPClient) DeleteDevice(ctx context.Context, applicationID, deviceID string) error {
+	path := fmt.Sprintf("%s/applications/%s/devices/%s", apiBase, applicationID, deviceID)
+	_, err := c.doRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil && strings.Contains(err.Error(), "status 404") {
+		return nil
+	}
+	return err
+}
+
+// clusterDeviceAttributes returns the standard attribute definitions for a cluster Edge Compute device.
+func clusterDeviceAttributes() []DeviceAttribute {
+	return []DeviceAttribute{
+		{Name: "health_score", DataType: "number"},
+		{Name: "health_status", DataType: "string"},
+		{Name: "total_nodes", DataType: "number"},
+		{Name: "ready_nodes", DataType: "number"},
+		{Name: "unhealthy_nodes", DataType: "number"},
+		{Name: "total_pods", DataType: "number"},
+		{Name: "running_pods", DataType: "number"},
+		{Name: "failed_pods", DataType: "number"},
+		{Name: "pending_pods", DataType: "number"},
+		{Name: "crashloop_pods", DataType: "number"},
+		{Name: "degraded_pvcs", DataType: "number"},
+		{Name: "coredns_healthy", DataType: "boolean"},
+		{Name: "event_warnings", DataType: "number"},
+	}
+}
+
+// nodeDeviceAttributes returns the standard attribute definitions for a node peripheral device.
+func nodeDeviceAttributes() []DeviceAttribute {
+	return []DeviceAttribute{
+		{Name: "health_score", DataType: "number"},
+		{Name: "health_status", DataType: "string"},
+		{Name: "ready", DataType: "boolean"},
+		{Name: "memory_pressure", DataType: "boolean"},
+		{Name: "disk_pressure", DataType: "boolean"},
+		{Name: "pid_pressure", DataType: "boolean"},
+		{Name: "pod_count", DataType: "number"},
+		{Name: "not_ready_pods", DataType: "number"},
+		{Name: "crashloop_pods", DataType: "number"},
+		{Name: "cpu_request_pct", DataType: "number"},
+		{Name: "mem_request_pct", DataType: "number"},
+	}
 }
 
 // clusterDeviceName returns the canonical Losant device name for a cluster.

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -159,6 +159,9 @@ func TestEnsureClusterDevice_Found(t *testing.T) {
 			Items []Device `json:"items"`
 		}{Items: []Device{{DeviceID: "cluster-dev-id", Name: "k8s-cluster-test-cluster"}}})
 	})
+	mux.HandleFunc("PATCH /applications/app-123/devices/cluster-dev-id", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct{}{})
+	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
@@ -302,6 +305,9 @@ func TestEnsureNodeDevice_Found(t *testing.T) {
 		writeJSON(w, struct {
 			Items []Device `json:"items"`
 		}{Items: []Device{{DeviceID: "existing-node-id", Name: "k8s-node-test-cluster-node-2"}}})
+	})
+	mux.HandleFunc("PATCH /applications/app-123/devices/existing-node-id", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct{}{})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -517,3 +517,156 @@ func TestGetDevice_InvalidJSON(t *testing.T) {
 		t.Fatal("expected error on invalid JSON device response, got nil")
 	}
 }
+
+// --- DeleteDevice ---
+
+func TestDeleteDevice_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /applications/app-123/devices/dev-to-delete", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct{}{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).DeleteDevice(context.Background(), "app-123", "dev-to-delete"); err != nil {
+		t.Fatalf("DeleteDevice on 200: unexpected error: %v", err)
+	}
+}
+
+func TestDeleteDevice_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /applications/app-123/devices/already-gone", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"type":"ResourceNotFound","message":"Device not found"}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).DeleteDevice(context.Background(), "app-123", "already-gone"); err != nil {
+		t.Fatalf("DeleteDevice on 404: expected nil (idempotent), got: %v", err)
+	}
+}
+
+func TestDeleteDevice_ServerError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("DELETE /applications/app-123/devices/bad-device", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"message":"internal error"}`, http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if err := newTestHTTPClient(srv.URL).DeleteDevice(context.Background(), "app-123", "bad-device"); err == nil {
+		t.Fatal("DeleteDevice on 500: expected error, got nil")
+	}
+}
+
+// --- Attribute population on device creation ---
+
+func TestEnsureClusterDevice_Created_HasAttributes(t *testing.T) {
+	var postBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{})
+	})
+	mux.HandleFunc("POST /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&postBody)
+		writeJSON(w, Device{DeviceID: "new-cluster-attr-id"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, err := newTestHTTPClient(srv.URL).EnsureClusterDevice(context.Background(), newTestSpec()); err != nil {
+		t.Fatalf("EnsureClusterDevice: %v", err)
+	}
+	attrs, ok := postBody["attributes"].([]interface{})
+	if !ok {
+		t.Fatalf("POST body missing 'attributes' field; body: %v", postBody)
+	}
+	if len(attrs) != 13 {
+		t.Errorf("cluster attribute count: got %d, want 13", len(attrs))
+	}
+}
+
+func TestEnsureNodeDevice_Created_HasAttributes(t *testing.T) {
+	var postBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{})
+	})
+	mux.HandleFunc("POST /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&postBody)
+		writeJSON(w, Device{DeviceID: "new-node-attr-id"})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-1", "gw-123"); err != nil {
+		t.Fatalf("EnsureNodeDevice: %v", err)
+	}
+	attrs, ok := postBody["attributes"].([]interface{})
+	if !ok {
+		t.Fatalf("POST body missing 'attributes' field; body: %v", postBody)
+	}
+	if len(attrs) != 11 {
+		t.Errorf("node attribute count: got %d, want 11", len(attrs))
+	}
+}
+
+// --- Attribute patching when device already exists ---
+
+func TestEnsureClusterDevice_Found_PatchHasAttributes(t *testing.T) {
+	var patchBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{Items: []Device{{DeviceID: "existing-cluster-id", Name: "k8s-cluster-test-cluster"}}})
+	})
+	mux.HandleFunc("PATCH /applications/app-123/devices/existing-cluster-id", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&patchBody)
+		writeJSON(w, struct{}{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, err := newTestHTTPClient(srv.URL).EnsureClusterDevice(context.Background(), newTestSpec()); err != nil {
+		t.Fatalf("EnsureClusterDevice: %v", err)
+	}
+	if patchBody == nil {
+		t.Fatal("PATCH handler was not called")
+	}
+	attrs, ok := patchBody["attributes"].([]interface{})
+	if !ok || len(attrs) != 13 {
+		t.Errorf("PATCH body: expected 13 cluster attributes, got: %v", patchBody["attributes"])
+	}
+}
+
+func TestEnsureNodeDevice_Found_PatchHasAttributes(t *testing.T) {
+	var patchBody map[string]interface{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /applications/app-123/devices", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, struct {
+			Items []Device `json:"items"`
+		}{Items: []Device{{DeviceID: "existing-node-attr-id", Name: "k8s-node-test-cluster-node-4"}}})
+	})
+	mux.HandleFunc("PATCH /applications/app-123/devices/existing-node-attr-id", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&patchBody)
+		writeJSON(w, struct{}{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	if _, err := newTestHTTPClient(srv.URL).EnsureNodeDevice(context.Background(), newTestSpec(), "node-4", "gw-xyz"); err != nil {
+		t.Fatalf("EnsureNodeDevice: %v", err)
+	}
+	if patchBody == nil {
+		t.Fatal("PATCH handler was not called")
+	}
+	attrs, ok := patchBody["attributes"].([]interface{})
+	if !ok || len(attrs) != 11 {
+		t.Errorf("PATCH body: expected 11 node attributes, got: %v", patchBody["attributes"])
+	}
+}

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -38,6 +38,8 @@ type MockClient struct {
 	UpdateDeviceTagsFunc      func(ctx context.Context, applicationID, deviceID string, tags map[string]string) error
 	GetDeviceFunc             func(ctx context.Context, applicationID, deviceID string) (*Device, error)
 	CreateDeviceAccessKeyFunc func(ctx context.Context, applicationID, deviceID, name string) (string, string, string, error)
+	PatchDeviceAttributesFunc func(ctx context.Context, applicationID, deviceID string, attrs []DeviceAttribute) error
+	DeleteDeviceFunc          func(ctx context.Context, applicationID, deviceID string) error
 
 	// Recorded calls — read after test assertions.
 	PingCalls                  []struct{}
@@ -46,6 +48,8 @@ type MockClient struct {
 	UpdateDeviceTagsCalls      []UpdateDeviceTagsCall
 	GetDeviceCalls             []GetDeviceCall
 	CreateDeviceAccessKeyCalls []CreateDeviceAccessKeyCall
+	PatchDeviceAttributesCalls []PatchDeviceAttributesCall
+	DeleteDeviceCalls          []DeleteDeviceCall
 }
 
 // EnsureClusterDeviceCall records one invocation of EnsureClusterDevice.
@@ -80,6 +84,19 @@ type CreateDeviceAccessKeyCall struct {
 	Name          string
 }
 
+// PatchDeviceAttributesCall records one invocation of PatchDeviceAttributes.
+type PatchDeviceAttributesCall struct {
+	ApplicationID string
+	DeviceID      string
+	Attrs         []DeviceAttribute
+}
+
+// DeleteDeviceCall records one invocation of DeleteDevice.
+type DeleteDeviceCall struct {
+	ApplicationID string
+	DeviceID      string
+}
+
 // NewMockClient returns a MockClient with sensible defaults:
 // EnsureClusterDevice returns "mock-cluster-device-id"
 // EnsureNodeDevice returns "mock-node-<nodeName>"
@@ -111,6 +128,12 @@ func (m *MockClient) SetError(err error) {
 	m.CreateDeviceAccessKeyFunc = func(_ context.Context, _, _, _ string) (string, string, string, error) {
 		return "", "", "", err
 	}
+	m.PatchDeviceAttributesFunc = func(_ context.Context, _, _ string, _ []DeviceAttribute) error {
+		return err
+	}
+	m.DeleteDeviceFunc = func(_ context.Context, _, _ string) error {
+		return err
+	}
 }
 
 // CallCount returns the total number of calls recorded across all methods.
@@ -122,7 +145,9 @@ func (m *MockClient) CallCount() int {
 		len(m.EnsureNodeDeviceCalls) +
 		len(m.UpdateDeviceTagsCalls) +
 		len(m.GetDeviceCalls) +
-		len(m.CreateDeviceAccessKeyCalls)
+		len(m.CreateDeviceAccessKeyCalls) +
+		len(m.PatchDeviceAttributesCalls) +
+		len(m.DeleteDeviceCalls)
 }
 
 // Reset clears all recorded calls and resets all HandlerFuncs to defaults.
@@ -135,12 +160,16 @@ func (m *MockClient) Reset() {
 	m.UpdateDeviceTagsFunc = nil
 	m.GetDeviceFunc = nil
 	m.CreateDeviceAccessKeyFunc = nil
+	m.PatchDeviceAttributesFunc = nil
+	m.DeleteDeviceFunc = nil
 	m.PingCalls = nil
 	m.EnsureClusterDeviceCalls = nil
 	m.EnsureNodeDeviceCalls = nil
 	m.UpdateDeviceTagsCalls = nil
 	m.GetDeviceCalls = nil
 	m.CreateDeviceAccessKeyCalls = nil
+	m.PatchDeviceAttributesCalls = nil
+	m.DeleteDeviceCalls = nil
 }
 
 // Ping implements LosantClient.
@@ -230,4 +259,37 @@ func (m *MockClient) CreateDeviceAccessKey(ctx context.Context, applicationID, d
 		return fn(ctx, applicationID, deviceID, name)
 	}
 	return "mock-key-id", "mock-access-key", "mock-access-secret", nil
+}
+
+// PatchDeviceAttributes implements LosantClient.
+func (m *MockClient) PatchDeviceAttributes(ctx context.Context, applicationID, deviceID string, attrs []DeviceAttribute) error {
+	m.mu.Lock()
+	m.PatchDeviceAttributesCalls = append(m.PatchDeviceAttributesCalls, PatchDeviceAttributesCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+		Attrs:         attrs,
+	})
+	fn := m.PatchDeviceAttributesFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID, attrs)
+	}
+	return nil
+}
+
+// DeleteDevice implements LosantClient.
+func (m *MockClient) DeleteDevice(ctx context.Context, applicationID, deviceID string) error {
+	m.mu.Lock()
+	m.DeleteDeviceCalls = append(m.DeleteDeviceCalls, DeleteDeviceCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+	})
+	fn := m.DeleteDeviceFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID)
+	}
+	return nil
 }

--- a/test/integration/losantsync_controller_test.go
+++ b/test/integration/losantsync_controller_test.go
@@ -34,7 +34,10 @@ const (
 
 func baseLosantSync(name string) *losantv1alpha1.LosantSync {
 	return &losantv1alpha1.LosantSync{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Finalizers: []string{"losant.io/device-cleanup"},
+		},
 		Spec: losantv1alpha1.LosantSyncSpec{
 			ApplicationID: "app-123",
 			ProvisioningSecretRef: losantv1alpha1.SecretRef{


### PR DESCRIPTION
## Summary

- `DeviceAttribute` struct; all device creations now send attribute definitions for both cluster (13) and node (11) device types
- `PatchDeviceAttributes` added to `LosantClient` interface + `HTTPClient`; called on `EnsureClusterDevice`/`EnsureNodeDevice` when device already exists (idempotent attribute reconciliation)
- `DeleteDevice` added to `LosantClient` interface + `HTTPClient`; 404 treated as success
- `cpu_request_pct` and `mem_request_pct` added to `nodeAttributes()` — now reported to GEA
- `losant.io/device-cleanup` finalizer lifecycle: added on every non-deleted CR; `handleDeletion` deletes all registered devices before removing it
- Warning logged when `clusterName` changes and cluster identity diverges
- `MockClient` updated with `PatchDeviceAttributes`/`DeleteDevice` methods, call recording, `SetError`, `Reset`, `CallCount`

Closes #296

## Blocked On

Issue #TBD — test-engineer must update tests on this branch before `make test` passes.
See handoff issue for exact instructions.

## Test plan

- [ ] Test-engineer handoff issue resolved — `make test` passes
- [x] `git diff --exit-code config/rbac/role.yaml` clean — no RBAC drift (finalizer uses existing `update` verb on `losantsyncs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)