### PR TITLE
test(e2e): add full device lifecycle scenarios against real Losant API

### DIFF
--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -229,7 +229,54 @@ These criteria require real Losant credentials (`LOSANT_APP_ID`, `LOSANT_API_TOK
 
 ---
 
-## 11. E2E Test Coverage Map
+## 11. GitOps-Compatible Deployment (Source-Independent)
+
+This scenario validates that the operator can be installed and operated without any local source tree, using only the published Helm OCI chart and the CRD asset bundled in the GitHub Release.
+
+**Prerequisites:**
+- A k3s or kind cluster is available with no source tree present
+- Helm 3.8 or later is installed (`helm version`)
+- The target release tag (e.g. `v0.1.0`) has been published to `ghcr.io` and the corresponding GitHub Release exists
+
+### Testable Statements — GitOps Deployment
+
+- **AC-GITOPS-01**: Installing the CRDs via `kubectl apply -f https://github.com/mak3r/losant-device/releases/download/<TAG>/crds.yaml` MUST succeed without error and the `LosantSync` CRD MUST be present in the cluster.
+- **AC-GITOPS-02**: Installing the operator via `helm install losant-device oci://ghcr.io/mak3r/losant-device/charts/losant-device:<VERSION> --create-namespace --namespace losant-device-system` MUST succeed and the controller pod MUST reach `Running` state within 60 seconds.
+- **AC-GITOPS-03**: `helm get metadata losant-device -n losant-device-system` MUST report a chart version that matches the release tag.
+- **AC-GITOPS-04**: A `LosantSync` CR applied after the Helm install MUST reach phase `Active` and begin reporting metrics, with no files from the source tree required at any point.
+
+### Manual Verification Steps
+
+```bash
+# 1. Install CRDs from the GitHub Release asset
+kubectl apply -f https://github.com/mak3r/losant-device/releases/download/<TAG>/crds.yaml
+
+# 2. Verify CRD is registered
+kubectl get crd losantsyncs.losant.mak3r.io
+
+# 3. Install the operator via OCI chart (Helm 3.8+)
+helm install losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<VERSION> \
+  --create-namespace \
+  --namespace losant-device-system \
+  --set provisioning.secretRef.name=losant-credentials \
+  --set provisioning.secretRef.namespace=losant-device-system
+
+# 4. Confirm controller pod is Running within 60s
+kubectl -n losant-device-system wait --for=condition=ready pod \
+  -l app.kubernetes.io/name=losant-device --timeout=60s
+
+# 5. Confirm chart version matches the release tag
+helm get metadata losant-device -n losant-device-system | grep version
+
+# 6. Apply a LosantSync CR and wait for Active
+kubectl apply -f losantsync-sample.yaml
+kubectl wait losantsync <name> --for=jsonpath='{.status.phase}'=Active --timeout=120s
+```
+
+---
+
+## 12. E2E Test Coverage Map
 
 | Criteria | Test File | Test Description | Status |
 |---|---|---|---|
@@ -259,4 +306,5 @@ These criteria require real Losant credentials (`LOSANT_APP_ID`, `LOSANT_API_TOK
 | AC-LIFECYCLE-02 | lifecycle_test.go | "patches all cluster attributes onto a pre-existing device that has no attributes" | Implemented |
 | AC-LIFECYCLE-03 | lifecycle_test.go | "recreates a cluster device that was manually deleted from Losant" | Implemented |
 | AC-LIFECYCLE-04 | lifecycle_test.go | "deletes all Losant devices when the CR is deleted" | Implemented |
+| AC-GITOPS-01..04 | — | Source-independent Helm OCI install + Active phase | Manual (no E2E automation; requires published release) |
 | CRD validation | validation_test.go | CEL rules, required fields, port range, defaults | Implemented |

--- a/docs/acceptance-criteria.md
+++ b/docs/acceptance-criteria.md
@@ -193,7 +193,43 @@ Look for lines containing:
 
 ---
 
-## 10. E2E Test Coverage Map
+## 10. Full Device Lifecycle (Attribute Definitions, Self-Healing, Cleanup)
+
+These criteria require real Losant credentials (`LOSANT_APP_ID`, `LOSANT_API_TOKEN`) and a live cluster with a reachable GEA pod. Tests skip automatically when credentials are absent.
+
+### Cluster device attributes (13)
+
+`health_score`, `health_status`, `total_nodes`, `ready_nodes`, `unhealthy_nodes`, `total_pods`, `running_pods`, `failed_pods`, `pending_pods`, `crashloop_pods`, `degraded_pvcs`, `coredns_healthy`, `event_warnings`
+
+### Node device attributes (11)
+
+`health_score`, `health_status`, `ready`, `memory_pressure`, `disk_pressure`, `pid_pressure`, `pod_count`, `not_ready_pods`, `crashloop_pods`, `cpu_request_pct`, `mem_request_pct`
+
+### Testable Statements — Device Lifecycle
+
+- **AC-LIFECYCLE-01**: When a `LosantSync` CR reaches phase `Active` on a clean application (no existing devices), the cluster Edge Compute device MUST have all 13 cluster attribute definitions and each node peripheral device MUST have all 11 node attribute definitions.
+  - *Preconditions*: No existing Losant devices for this cluster name. Valid KUBECONFIG, LOSANT_APP_ID, LOSANT_API_TOKEN. GEA reachable.
+  - *Steps*: Apply CR → wait for `Active` → `GET /applications/{appID}/devices/{clusterDeviceID}` → assert 13 attributes → repeat for each node device ID in `Status.NodeDevices`.
+  - *Expected*: All cluster and node devices carry the expected attribute schema.
+
+- **AC-LIFECYCLE-02**: When a cluster device already exists in Losant with no attributes, the operator MUST patch all 13 cluster attribute definitions onto it during the next `EnsureClusterDevice` call.
+  - *Preconditions*: A device named `k8s-cluster-<clusterName>` exists in Losant with no attributes. Valid credentials and reachable GEA.
+  - *Steps*: Pre-create bare device → apply CR with matching `clusterName` → wait for `Active` → `GET` the pre-existing device → assert all 13 attributes present.
+  - *Expected*: The pre-existing device's attribute set is augmented to the full cluster schema without recreation.
+
+- **AC-LIFECYCLE-03**: When the cluster device is deleted directly from Losant, the controller MUST detect the absence on the next reconcile cycle and recreate it with a new device ID and all 13 cluster attribute definitions. Phase MUST return to `Active`.
+  - *Preconditions*: CR is `Active`. Valid credentials. GEA reachable.
+  - *Steps*: Wait for `Active` → note `Status.ClusterDeviceID` → delete device via Losant API → wait up to 2× the configured interval → assert `Status.ClusterDeviceID` changed AND phase is `Active` → fetch new device → assert 13 attributes.
+  - *Expected*: Controller self-heals by recreating the missing device within one reconcile cycle.
+
+- **AC-LIFECYCLE-04**: Deleting a `LosantSync` CR MUST trigger the `losant.io/device-cleanup` finalizer, which MUST delete the cluster device and all node devices from Losant before the CR is removed from the API server.
+  - *Preconditions*: CR is `Active`. Valid credentials.
+  - *Steps*: Note `Status.ClusterDeviceID` and all `Status.NodeDevices` values → delete CR → wait for CR to be fully gone (no finalizer remaining) → `GET` each device ID → assert all return 404.
+  - *Expected*: All registered Losant devices are deleted; none return 200 after CR removal.
+
+---
+
+## 11. E2E Test Coverage Map
 
 | Criteria | Test File | Test Description | Status |
 |---|---|---|---|
@@ -219,4 +255,8 @@ Look for lines containing:
 | AC-SUSP-03 | lifecycle_test.go | No HTTP calls while suspended | Implemented |
 | AC-SUSP-04 | lifecycle_test.go | Resume from suspension → Provisioning | Implemented |
 | AC-SUSP-05 | lifecycle_test.go | "phase remains Suspended when reconciled repeatedly" | Implemented |
+| AC-LIFECYCLE-01 | lifecycle_test.go | "creates cluster and node devices with all expected attribute definitions" | Implemented |
+| AC-LIFECYCLE-02 | lifecycle_test.go | "patches all cluster attributes onto a pre-existing device that has no attributes" | Implemented |
+| AC-LIFECYCLE-03 | lifecycle_test.go | "recreates a cluster device that was manually deleted from Losant" | Implemented |
+| AC-LIFECYCLE-04 | lifecycle_test.go | "deletes all Losant devices when the CR is deleted" | Implemented |
 | CRD validation | validation_test.go | CEL rules, required fields, port range, defaults | Implemented |

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -17,11 +17,17 @@ limitations under the License.
 package e2e_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"sync/atomic"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -164,4 +170,144 @@ func uncordonNode(ctx context.Context, nodeName string) {
 	}
 	node.Spec.Unschedulable = false
 	_ = k8sClient.Update(ctx, node)
+}
+
+// --- Real Losant REST API helpers (require LOSANT_APP_ID and LOSANT_API_TOKEN env vars) ---
+
+const (
+	losantAPIBase     = "https://api.losant.com"
+	e2eRealSecretName = "losant-real-credentials"
+)
+
+var losantTestHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// losantDeviceResp is a minimal Losant REST device representation for E2E test assertions.
+type losantDeviceResp struct {
+	DeviceID   string           `json:"deviceId"`
+	Name       string           `json:"name"`
+	Attributes []losantAttrResp `json:"attributes"`
+}
+
+// losantAttrResp holds one telemetry attribute returned by the Losant REST API.
+type losantAttrResp struct {
+	Name     string `json:"name"`
+	DataType string `json:"dataType"`
+}
+
+// skipUnlessRealLosant skips the current spec when real Losant credentials are absent.
+func skipUnlessRealLosant() {
+	if os.Getenv("LOSANT_APP_ID") == "" || os.Getenv("LOSANT_API_TOKEN") == "" {
+		Skip("LOSANT_APP_ID or LOSANT_API_TOKEN not set — requires real Losant credentials")
+	}
+}
+
+// losantDo executes an authenticated request against the Losant REST API and returns the
+// response body and HTTP status code. Transport-level failures are fatal to the test.
+func losantDo(method, path string, payload interface{}) ([]byte, int) {
+	token := os.Getenv("LOSANT_API_TOKEN")
+	var reqBody io.Reader
+	if payload != nil {
+		b, err := json.Marshal(payload)
+		Expect(err).NotTo(HaveOccurred(), "marshal losant request payload")
+		reqBody = bytes.NewReader(b)
+	}
+	req, err := http.NewRequest(method, losantAPIBase+path, reqBody)
+	Expect(err).NotTo(HaveOccurred(), "build losant request")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := losantTestHTTPClient.Do(req)
+	Expect(err).NotTo(HaveOccurred(), "losant %s %s", method, path)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	Expect(err).NotTo(HaveOccurred(), "read losant response body")
+	return body, resp.StatusCode
+}
+
+// losantFetchDevice calls GET /applications/{appID}/devices/{deviceID}.
+// Returns (device, statusCode); device is nil when status >= 400.
+func losantFetchDevice(appID, deviceID string) (*losantDeviceResp, int) {
+	body, status := losantDo(http.MethodGet,
+		fmt.Sprintf("/applications/%s/devices/%s", appID, deviceID), nil)
+	if status >= 400 {
+		return nil, status
+	}
+	var d losantDeviceResp
+	Expect(json.Unmarshal(body, &d)).To(Succeed(), "decode losant device response")
+	return &d, status
+}
+
+// losantAttrNames extracts attribute names from a device response for use with Gomega matchers.
+func losantAttrNames(d *losantDeviceResp) []string {
+	names := make([]string, len(d.Attributes))
+	for i, a := range d.Attributes {
+		names[i] = a.Name
+	}
+	return names
+}
+
+// losantCreateBareDevice creates a Losant device with no attributes and returns its device ID.
+func losantCreateBareDevice(appID, name, class string) string {
+	payload := map[string]interface{}{
+		"name":        name,
+		"deviceClass": class,
+	}
+	body, status := losantDo(http.MethodPost,
+		fmt.Sprintf("/applications/%s/devices", appID), payload)
+	Expect(status).To(BeNumerically("<", 300),
+		"create bare losant device %q: %s", name, string(body))
+	var d losantDeviceResp
+	Expect(json.Unmarshal(body, &d)).To(Succeed())
+	Expect(d.DeviceID).NotTo(BeEmpty())
+	return d.DeviceID
+}
+
+// losantDeleteDevice deletes a Losant device; ignores 404 (already gone).
+func losantDeleteDevice(appID, deviceID string) {
+	_, status := losantDo(http.MethodDelete,
+		fmt.Sprintf("/applications/%s/devices/%s", appID, deviceID), nil)
+	Expect(status).To(Or(BeNumerically("<", 300), Equal(404)),
+		"delete losant device %s", deviceID)
+}
+
+// ensureRealLosantSecret creates a k8s Secret holding the real Losant API token.
+func ensureRealLosantSecret(ctx context.Context) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      e2eRealSecretName,
+			Namespace: e2eNamespace,
+		},
+		StringData: map[string]string{
+			"api-token": os.Getenv("LOSANT_API_TOKEN"),
+		},
+	}
+	err := k8sClient.Create(ctx, secret)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred(), "creating real losant credentials secret")
+	}
+}
+
+// newRealLosantSync returns a LosantSync pointing at the real Losant application and credentials.
+// ClusterName is set to name so the canonical device name (k8s-cluster-<name>) is unique per test.
+func newRealLosantSync(name, interval string) *losantv1alpha1.LosantSync {
+	ls := &losantv1alpha1.LosantSync{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: losantv1alpha1.LosantSyncSpec{
+			ApplicationID: os.Getenv("LOSANT_APP_ID"),
+			ProvisioningSecretRef: losantv1alpha1.SecretRef{
+				Name:      e2eRealSecretName,
+				Namespace: e2eNamespace,
+			},
+			ClusterName: name,
+			Region:      "us-east-1",
+			GEA: losantv1alpha1.GEASpec{
+				ServiceRef: "losant-gea",
+				Port:       8080,
+			},
+		},
+	}
+	if interval != "" {
+		ls.Spec.Interval = interval
+	}
+	return ls
 }

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package e2e_test
 
 import (
+	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	losantv1alpha1 "github.com/mak3r/losant-device/api/v1alpha1"
 )
@@ -584,5 +588,147 @@ var _ = Describe("LosantSync lifecycle", func() {
 			Expect(cond).NotTo(BeNil())
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
+	})
+})
+
+// clusterAttributeNames lists the 13 telemetry attributes expected on a cluster Edge Compute device.
+var clusterAttributeNames = []string{
+	"health_score", "health_status", "total_nodes", "ready_nodes", "unhealthy_nodes",
+	"total_pods", "running_pods", "failed_pods", "pending_pods", "crashloop_pods",
+	"degraded_pvcs", "coredns_healthy", "event_warnings",
+}
+
+// nodeAttributeNames lists the 11 telemetry attributes expected on a node peripheral device.
+var nodeAttributeNames = []string{
+	"health_score", "health_status", "ready", "memory_pressure", "disk_pressure",
+	"pid_pressure", "pod_count", "not_ready_pods", "crashloop_pods",
+	"cpu_request_pct", "mem_request_pct",
+}
+
+// AC-LIFECYCLE-01..04
+// These tests require LOSANT_APP_ID and LOSANT_API_TOKEN env vars and a live cluster with a
+// reachable GEA pod. Skip automatically when real Losant credentials are absent.
+var _ = Describe("LosantSync device lifecycle against real Losant API", func() {
+
+	BeforeEach(func() {
+		skipUnlessRealLosant()
+		ensureTestNamespaceAndSecret(ctx)
+		ensureRealLosantSecret(ctx)
+	})
+
+	// AC-LIFECYCLE-01: fresh CR provisions devices with all expected attribute definitions.
+	It("creates cluster and node devices with all expected attribute definitions", func() {
+		name := uniqueName("lc-attrs")
+		Expect(k8sClient.Create(ctx, newRealLosantSync(name, "5m"))).To(Succeed())
+		DeferCleanup(func() { cleanupLosantSync(ctx, name) })
+
+		Eventually(func() losantv1alpha1.LosantSyncPhase {
+			return getLosantSync(ctx, name).Status.Phase
+		}, 120*time.Second, pollInterval).Should(Equal(losantv1alpha1.PhaseActive))
+
+		current := getLosantSync(ctx, name)
+		appID := os.Getenv("LOSANT_APP_ID")
+
+		clusterDev, status := losantFetchDevice(appID, current.Status.ClusterDeviceID)
+		Expect(status).To(Equal(200))
+		Expect(losantAttrNames(clusterDev)).To(ConsistOf(clusterAttributeNames))
+
+		for nodeName, nodeDeviceID := range current.Status.NodeDevices {
+			nodeDev, s := losantFetchDevice(appID, nodeDeviceID)
+			Expect(s).To(Equal(200), "fetch node device for %s", nodeName)
+			Expect(losantAttrNames(nodeDev)).To(ConsistOf(nodeAttributeNames),
+				"node device for %s should have all expected attributes", nodeName)
+		}
+	})
+
+	// AC-LIFECYCLE-02: operator patches attributes onto a pre-existing device that has none.
+	It("patches all cluster attributes onto a pre-existing device that has no attributes", func() {
+		name := uniqueName("lc-patch")
+		appID := os.Getenv("LOSANT_APP_ID")
+
+		// Pre-create a cluster device with no attributes using the canonical name.
+		bareDeviceID := losantCreateBareDevice(appID,
+			fmt.Sprintf("k8s-cluster-%s", name), "edgeCompute")
+		DeferCleanup(func() { losantDeleteDevice(appID, bareDeviceID) })
+
+		Expect(k8sClient.Create(ctx, newRealLosantSync(name, "5m"))).To(Succeed())
+		DeferCleanup(func() { cleanupLosantSync(ctx, name) })
+
+		Eventually(func() losantv1alpha1.LosantSyncPhase {
+			return getLosantSync(ctx, name).Status.Phase
+		}, 120*time.Second, pollInterval).Should(Equal(losantv1alpha1.PhaseActive))
+
+		clusterDev, status := losantFetchDevice(appID, bareDeviceID)
+		Expect(status).To(Equal(200))
+		Expect(losantAttrNames(clusterDev)).To(ConsistOf(clusterAttributeNames),
+			"operator must patch all cluster attributes onto the pre-existing device")
+	})
+
+	// AC-LIFECYCLE-03: controller recreates a cluster device deleted directly in Losant.
+	// Uses a 1m interval so self-healing completes within the 120s Eventually window.
+	It("recreates a cluster device that was manually deleted from Losant", func() {
+		name := uniqueName("lc-heal")
+		Expect(k8sClient.Create(ctx, newRealLosantSync(name, "1m"))).To(Succeed())
+		DeferCleanup(func() { cleanupLosantSync(ctx, name) })
+
+		Eventually(func() losantv1alpha1.LosantSyncPhase {
+			return getLosantSync(ctx, name).Status.Phase
+		}, 120*time.Second, pollInterval).Should(Equal(losantv1alpha1.PhaseActive))
+
+		appID := os.Getenv("LOSANT_APP_ID")
+		originalDeviceID := getLosantSync(ctx, name).Status.ClusterDeviceID
+		Expect(originalDeviceID).NotTo(BeEmpty())
+
+		losantDeleteDevice(appID, originalDeviceID)
+
+		// Wait for the controller to detect the missing device and recreate it (up to 2× interval).
+		Eventually(func() bool {
+			current := getLosantSync(ctx, name)
+			newID := current.Status.ClusterDeviceID
+			return newID != "" && newID != originalDeviceID &&
+				current.Status.Phase == losantv1alpha1.PhaseActive
+		}, 120*time.Second, pollInterval).Should(BeTrue(),
+			"controller should self-heal by creating a new cluster device")
+
+		newDeviceID := getLosantSync(ctx, name).Status.ClusterDeviceID
+		newDev, status := losantFetchDevice(appID, newDeviceID)
+		Expect(status).To(Equal(200))
+		Expect(losantAttrNames(newDev)).To(ConsistOf(clusterAttributeNames),
+			"recreated device must have all cluster attribute definitions")
+	})
+
+	// AC-LIFECYCLE-04: deleting a CR triggers the finalizer which removes all Losant devices.
+	It("deletes all Losant devices when the CR is deleted", func() {
+		name := uniqueName("lc-finalizer")
+		Expect(k8sClient.Create(ctx, newRealLosantSync(name, "5m"))).To(Succeed())
+
+		Eventually(func() losantv1alpha1.LosantSyncPhase {
+			return getLosantSync(ctx, name).Status.Phase
+		}, 120*time.Second, pollInterval).Should(Equal(losantv1alpha1.PhaseActive))
+
+		current := getLosantSync(ctx, name)
+		clusterDeviceID := current.Status.ClusterDeviceID
+		nodeDeviceIDs := make([]string, 0, len(current.Status.NodeDevices))
+		for _, id := range current.Status.NodeDevices {
+			nodeDeviceIDs = append(nodeDeviceIDs, id)
+		}
+
+		appID := os.Getenv("LOSANT_APP_ID")
+
+		Expect(k8sClient.Delete(ctx, current)).To(Succeed())
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, &losantv1alpha1.LosantSync{})
+			return apierrors.IsNotFound(err)
+		}, 120*time.Second, pollInterval).Should(BeTrue(),
+			"CR should be fully removed once the finalizer completes device cleanup")
+
+		_, status := losantFetchDevice(appID, clusterDeviceID)
+		Expect(status).To(Equal(404), "cluster device must be deleted from Losant after CR deletion")
+
+		for _, nodeDeviceID := range nodeDeviceIDs {
+			_, s := losantFetchDevice(appID, nodeDeviceID)
+			Expect(s).To(Equal(404),
+				"node device %s must be deleted from Losant after CR deletion", nodeDeviceID)
+		}
 	})
 })


### PR DESCRIPTION
## Summary

- Adds `AC-LIFECYCLE-01..04` E2E test scenarios to `test/e2e/lifecycle_test.go`: device attribute verification on fresh creation, attribute patch on pre-existing devices, cluster device self-healing after manual deletion, and CR-deletion finalizer cleanup
- Adds Losant REST API helpers to `test/e2e/helpers_test.go` (`losantFetchDevice`, `losantCreateBareDevice`, `losantDeleteDevice`, `newRealLosantSync`, etc.); tests skip automatically when `LOSANT_APP_ID` / `LOSANT_API_TOKEN` are absent
- Updates `docs/acceptance-criteria.md` with a new §10 documenting the four lifecycle acceptance criteria and adds all four to the §11 coverage map

Closes #298

## Test plan

- [ ] Run `make e2e` with `LOSANT_APP_ID` and `LOSANT_API_TOKEN` set against a live k3s cluster with a reachable GEA pod — all 4 `AC-LIFECYCLE-*` specs should pass
- [ ] Run `make e2e` without those env vars — all 4 specs should be `Skip`ped, no failures
- [ ] `go test -c ./test/e2e/` compiles cleanly (no cluster required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)