### PR TITLE
docs(setup): OCI Helm install, CRD-first pattern, and upgrade procedure

### DIFF
--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -4,30 +4,85 @@ Install the losant-device operator and GEA with Helm, then apply the LosantSync 
 
 ## Prerequisites
 
-- `helm` v3.x installed
+- **Helm 3.8 or later** — required for OCI registry support (`helm version`)
+- `kubectl` with access to your cluster
+- Access to `ghcr.io` (no authentication required for public images)
 - `losant-provisioning-credentials` Secret created (see [Step 2](2-kubernetes-preparation.md))
 
 ---
 
-## Install with Helm
+## Install via OCI Chart
+
+Replace `<VERSION>` with a release tag (e.g. `v0.1.0`). See the [releases page](https://github.com/mak3r/losant-device/releases) for available versions.
+
+### Standard install (Helm-managed CRDs)
+
+This is the default path. Helm installs CRDs as part of the chart install and manages their lifecycle.
 
 ```bash
-helm install losant-device helm/ \
-  --namespace losant-system \
-  --create-namespace
+helm install losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<VERSION> \
+  --create-namespace \
+  --namespace losant-system
 ```
+
+### CRD-first install (GitOps environments)
+
+GitOps tools such as Flux and ArgoCD typically manage CRDs as cluster-scoped infrastructure, separate from application charts. In these environments, apply the standalone CRD manifest before installing the chart and pass `--skip-crds` so Helm does not attempt to manage them.
+
+```bash
+# Step 1 — apply CRDs to the cluster
+kubectl apply -f https://github.com/mak3r/losant-device/releases/download/<VERSION>/crds.yaml
+
+# Step 2 — install the chart without the CRD install step
+helm install losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<VERSION> \
+  --create-namespace \
+  --namespace losant-system \
+  --skip-crds
+```
+
+**Which pattern to choose:**
+
+| Pattern | When to use |
+|---|---|
+| **Standard (Helm-managed CRDs)** | Direct `helm install`; Helm owns the full lifecycle |
+| **CRD-first** | Flux `HelmRelease`, ArgoCD `Application`, Terraform, Ansible — tools that treat CRDs as cluster infrastructure outside of app charts |
 
 This deploys:
 - The losant-device controller Deployment and RBAC
 - The GEA Deployment, Service, PersistentVolumeClaim, and ServiceAccount
 
-> **Published image**: The chart defaults to the latest published image at `ghcr.io/mak3r/losant-device`. To pin a specific version:
-> ```bash
-> helm install losant-device helm/ \
->   --namespace losant-system \
->   --create-namespace \
->   --set controller.image.tag=v0.1.0-alpha.4
-> ```
+---
+
+## Upgrade
+
+To upgrade to a new release, run `helm upgrade` with the new version tag:
+
+```bash
+helm upgrade losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<NEW_VERSION> \
+  --namespace losant-system
+```
+
+If you are using the **CRD-first** pattern, apply the new CRD manifest **before** running `helm upgrade`:
+
+```bash
+kubectl apply -f https://github.com/mak3r/losant-device/releases/download/<NEW_VERSION>/crds.yaml
+
+helm upgrade losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<NEW_VERSION> \
+  --namespace losant-system
+```
+
+To pin the controller image to a specific tag (overrides the chart default):
+
+```bash
+helm upgrade losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<NEW_VERSION> \
+  --namespace losant-system \
+  --set controller.image.tag=<NEW_VERSION>
+```
 
 ---
 

--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -26,7 +26,7 @@ This deploys:
 > helm install losant-device helm/ \
 >   --namespace losant-system \
 >   --create-namespace \
->   --set image.tag=v0.1.0-alpha.4
+>   --set controller.image.tag=v0.1.0-alpha.4
 > ```
 
 ---


### PR DESCRIPTION
## Summary

- Updates `docs/setup/3-deploy.md` to replace local `helm/` directory install with OCI chart install as the primary path
- Adds CRD-first install pattern section for GitOps tools (Flux, ArgoCD, Terraform, Ansible) with `--skip-crds` guidance
- Adds upgrade procedure for both standard and CRD-first patterns
- States Helm 3.8+ prerequisite required for OCI registry support

Closes #293

## Test plan

- [ ] OCI install command references correct chart path: `oci://ghcr.io/mak3r/losant-device/charts/losant-device:<VERSION>`
- [ ] CRD-first pattern uses `--skip-crds` and references `crds.yaml` release asset URL
- [ ] Upgrade procedure covers both standard and CRD-first paths
- [ ] Helm 3.8+ prerequisite stated in prerequisites section
- [ ] No `*.go` or `helm/templates/**` files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)