### PR TITLE
ci(release): Helm OCI chart publish and install smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,76 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+  publish-chart:
+    runs-on: ubuntu-latest
+    needs: [release]
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Inject Chart version from tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          APP_VERSION="${TAG#v}"
+          sed -i "s/^version:.*/version: ${APP_VERSION}/" helm/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: ${APP_VERSION}/" helm/Chart.yaml
+      - name: Log in to GHCR Helm registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Package and push Helm chart
+        run: |
+          helm package helm/
+          helm push losant-device-*.tgz oci://ghcr.io/mak3r/losant-device/charts
+      - name: Upload CRD asset to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat config/crd/bases/*.yaml > crds.yaml
+          gh release upload "${GITHUB_REF_NAME}" crds.yaml
+
+  chart-install-smoke:
+    runs-on: ubuntu-latest
+    needs: [publish-chart]
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Install kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+      - name: Create kind cluster
+        run: kind create cluster --wait 60s
+      - name: Log in to GHCR Helm registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Install Helm chart from OCI
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          APP_VERSION="${TAG#v}"
+          helm install losant-device \
+            oci://ghcr.io/mak3r/losant-device/charts/losant-device \
+            --version "${APP_VERSION}" \
+            --create-namespace \
+            --namespace losant-device-system \
+            --wait \
+            --timeout 120s
+      - name: Assert CRD is registered
+        run: kubectl get crd losantsyncs.losant.losant.com
+      - name: Assert controller pod is Running
+        run: |
+          kubectl wait --for=condition=Ready pod \
+            -l control-plane=controller-manager \
+            -n losant-device-system \
+            --timeout=120s
+      - name: Assert chart version matches release tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          APP_VERSION="${TAG#v}"
+          CHART_VERSION=$(helm get metadata losant-device -n losant-device-system -o json | jq -r '.version')
+          if [ "${CHART_VERSION}" != "${APP_VERSION}" ]; then
+            echo "ERROR: chart version '${CHART_VERSION}' does not match expected '${APP_VERSION}'"
+            exit 1
+          fi
+          echo "Chart version verified: ${CHART_VERSION}"


### PR DESCRIPTION
## Summary

- Adds `publish-chart` job to `release.yml`: injects the git tag version into `Chart.yaml`, packages and pushes the Helm chart to `oci://ghcr.io/mak3r/losant-device/charts`, and uploads `crds.yaml` as a GitHub Release asset
- Adds `chart-install-smoke` job: spins up a `kind` cluster, installs the chart from OCI, and asserts CRD registration, controller pod Running state, and chart version match against the release tag
- Permissions approved by security in #288; cosign deferred to #302

Closes #290
Closes #291

## Test plan

- [ ] Trigger a release tag push (`v*`) and verify `publish-chart` job pushes chart to GHCR and uploads `crds.yaml` to the GitHub Release
- [ ] Verify `chart-install-smoke` job runs after `publish-chart`, installs chart from OCI reference, and all assertions pass
- [ ] Confirm `config/rbac/role.yaml` shows no drift (`make manifests && git diff --exit-code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)