### PR TITLE
fix(security): add docker/login-action to publish-chart so cosign can push signature to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: sigstore/cosign-installer@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Inject Chart version from tag
         run: |
           TAG="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary

- Adds `docker/login-action@v3` to the `publish-chart` job in `release.yml`, after `sigstore/cosign-installer` and before the chart injection step
- Without this, cosign generates the ephemeral key and logs to Rekor successfully but fails to push the signature blob back to GHCR with `UNAUTHORIZED`
- The `release` job already had this login step; `publish-chart` was missing it

Closes #307

## Root cause

`helm registry login` sets up credentials for Helm's OCI client only. Cosign uses the Docker credential store to push signatures — that store is only populated by `docker/login-action` (or `docker login`). The `release` job has it; `publish-chart` did not.

## Verification

Confirmed by failed release run `25327851951` for `v0.1.0-alpha.12`: cosign sign succeeded up to the push step, then returned `UNAUTHORIZED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)