### PR TITLE
fix(security): add docker/login-action to publish-chart — unblock v0.1.0-alpha.12 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: sigstore/cosign-installer@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Inject Chart version from tag
         run: |
           TAG="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Summary

- Brings the `docker/login-action` fix from #308 into `main` to unblock the `v0.1.0-alpha.12` release
- The `publish-chart` job was missing `docker/login-action@v3`, causing cosign to fail pushing the Helm chart signature to GHCR with `UNAUTHORIZED`

Closes #307

## Post-merge

After merging, delete and re-push the `v0.1.0-alpha.12` tag to re-trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)