### PR TITLE
fix(helm): add namespace template and fix smoke test namespace assertion

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           kubectl wait --for=condition=Ready pod \
             -l control-plane=controller-manager \
-            -n losant-device-system \
+            -n losant-system \
             --timeout=120s
       - name: Assert chart version matches release tag
         run: |

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Add `helm/templates/namespace.yaml` — `namespace.create: true` in values had no effect because no template existed; chart resources using `{{ .Values.namespace.name }}` (defaults to `losant-system`) were failing because the namespace didn't exist
- Fix `chart-install-smoke` pod assertion to check `-n losant-system` instead of `-n losant-device-system` (the `--namespace` flag at install time is the Helm release tracking namespace, not the resource namespace)

Unblocks v0.1.0-alpha.13 smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)