### PR TITLE
fix(release): correct CRD name in smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
             --create-namespace \
             --namespace losant-device-system
       - name: Assert CRD is registered
-        run: kubectl wait --for=condition=Established crd/losantsyncs.losant.losant.com --timeout=60s
+        run: kubectl wait --for=condition=Established crd/losantsyncs.losant.io --timeout=60s
       - name: Assert controller Deployment was created
         run: kubectl get deployment -n losant-system -l control-plane=controller-manager
       - name: Assert chart version matches release tag


### PR DESCRIPTION
## Summary

- Fix wrong CRD name in `chart-install-smoke`: `losantsyncs.losant.losant.com` → `losantsyncs.losant.io` (matches `config/crd/bases/*.yaml` and the Helm chart's `crd.yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)