### PR TITLE
fix(ci): retain v prefix in appVersion when packaging Helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           APP_VERSION="${TAG#v}"
           sed -i "s/^version:.*/version: ${APP_VERSION}/" helm/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: ${APP_VERSION}/" helm/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: ${TAG}/" helm/Chart.yaml
       - name: Package and push Helm chart
         id: helm-push
         env:


### PR DESCRIPTION
## Summary
- The `publish-chart` job was stripping the `v` prefix from `appVersion` via `${TAG#v}`, producing `0.1.0-alpha.13` instead of `v0.1.0-alpha.13`
- The Helm deployment template defaults `controller.image.tag` to `Chart.AppVersion`, so chart installs used the tag without `v` — which doesn't exist on GHCR
- Fix: `chart version` (Helm SemVer field) continues to strip `v`; `appVersion` now uses `${TAG}` directly to match the published image tag

## Test plan
- [ ] Confirm next release tag produces `appVersion: v<tag>` in the packaged chart
- [ ] Confirm `helm install` from the OCI artifact resolves the correct image (`ghcr.io/mak3r/losant-device:v<tag>`)
- [ ] Chart smoke test (`chart-install-smoke` job) passes with controller pod `Running`

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)