### PR TITLE
fix(docs): remove namespace pre-creation to prevent Helm ownership conflict

### DIFF
--- a/docs/setup/2-kubernetes-preparation.md
+++ b/docs/setup/2-kubernetes-preparation.md
@@ -1,6 +1,6 @@
 # Step 2: Kubernetes Preparation
 
-Create the provisioning Secret the controller needs to authenticate to the Losant REST API.
+Verify that `kubectl` is connected to your target cluster and gather the information you need before deploying.
 
 ## Prerequisites
 
@@ -20,26 +20,22 @@ Confirm the context points to the cluster you intend to deploy to before proceed
 
 ---
 
-## Create the provisioning Secret
+## About the provisioning Secret
 
-The Helm chart creates the `losant-system` namespace automatically. If you are pre-creating it:
+The controller authenticates to the Losant REST API using a Kubernetes Secret named `losant-provisioning-credentials`. You will create this Secret in Step 3, after Helm installs the operator and creates the `losant-system` namespace.
 
-```bash
-kubectl create namespace losant-system --dry-run=client -o yaml | kubectl apply -f -
-```
+> **Do not pre-create the `losant-system` namespace.** Helm creates it with proper ownership metadata during `helm install`. Pre-creating the namespace causes an `invalid ownership metadata` error that prevents installation.
 
-Create the provisioning Secret:
+The Secret requires exactly one key:
 
-```bash
-kubectl create secret generic losant-provisioning-credentials \
-  --from-literal=api-token=<application-api-token-from-step-1> \
-  -n losant-system
-```
+| Key | Value |
+|---|---|
+| `api-token` | Application API Token from Step 1 |
 
-> **Key name matters**: The controller reads a single `api-token` key from this Secret. Any other key name causes a startup error.
+> **Key name matters**: The controller reads the `api-token` key specifically. Any other key name causes a startup error.
 
 ---
 
 ## Next step
 
-**[Step 3 → Deploy](3-deploy.md)** — install the operator with Helm and apply the LosantSync CR.
+**[Step 3 → Deploy](3-deploy.md)** — install the operator with Helm, create the provisioning Secret, and apply the LosantSync CR.

--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -7,7 +7,7 @@ Install the losant-device operator and GEA with Helm, then apply the LosantSync 
 - **Helm 3.8 or later** — required for OCI registry support (`helm version`)
 - `kubectl` with access to your cluster
 - Access to `ghcr.io` (no authentication required for public images)
-- `losant-provisioning-credentials` Secret created (see [Step 2](2-kubernetes-preparation.md))
+- Application API Token from [Step 1](1-losant-application.md)
 
 ---
 
@@ -52,6 +52,20 @@ helm install losant-device \
 This deploys:
 - The losant-device controller Deployment and RBAC
 - The GEA Deployment, Service, PersistentVolumeClaim, and ServiceAccount
+
+---
+
+## Create the provisioning Secret
+
+Now that Helm has created the `losant-system` namespace, create the Secret the controller uses to authenticate to the Losant REST API. Replace `<application-api-token-from-step-1>` with the token from [Step 1](1-losant-application.md).
+
+```bash
+kubectl create secret generic losant-provisioning-credentials \
+  --from-literal=api-token=<application-api-token-from-step-1> \
+  -n losant-system
+```
+
+> **Key name matters**: The controller reads the `api-token` key specifically. Any other key name causes a startup error.
 
 ---
 


### PR DESCRIPTION
## Summary

- Removes the `kubectl create namespace` pre-creation step from `docs/setup/2-kubernetes-preparation.md` — Helm creates `losant-system` with proper ownership metadata; pre-creating it causes `invalid ownership metadata` errors
- Adds an explicit warning not to pre-create the namespace
- Moves `kubectl create secret` for `losant-provisioning-credentials` to `docs/setup/3-deploy.md`, after `helm install` creates the namespace

## Test plan

- [ ] Follow the updated guide on a fresh cluster: verify `helm install` succeeds without the namespace pre-existing
- [ ] Verify `kubectl create secret` succeeds after `helm install` (namespace now exists)
- [ ] Verify the LosantSync CR reconciles successfully with the secret in place

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)