### PR TITLE
fix(controller): requeue after finalizer add to prevent reconciler stall (#329)

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -79,9 +79,15 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return r.handleDeletion(ctx, &ls)
 	}
 
-	// Add finalizer on first non-deleted reconcile; requeue to confirm write.
+	// Add finalizer on first non-deleted reconcile. Explicit requeue is required
+	// because GenerationChangedPredicate filters out metadata-only watch events
+	// (finalizer writes do not bump .metadata.generation), so without Requeue the
+	// reconciler would stall permanently after this Update.
 	if controllerutil.AddFinalizer(&ls, "losant.io/device-cleanup") {
-		return ctrl.Result{}, r.Update(ctx, &ls)
+		if err := r.Update(ctx, &ls); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Suspend: halt all reconciliation.

--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -566,6 +566,25 @@ func TestFinalizerAddedOnFirstReconcile(t *testing.T) {
 	}
 }
 
+// TestFinalizerAddRequeues is a regression test for the stall described in #329:
+// after adding the losant.io/device-cleanup finalizer the reconciler must return
+// Requeue=true so that the sync cycle proceeds despite GenerationChangedPredicate
+// filtering out the metadata-only watch event that the finalizer write produces.
+func TestFinalizerAddRequeues(t *testing.T) {
+	ls := baseLS("add-finalizer-requeue")
+	ls.Finalizers = nil // exercise the finalizer-add branch
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, losant.NewMockClient(), gea.NewMockClient(), monitor.NewHealthStore())
+
+	result, err := r.Reconcile(context.Background(), reqFor(ls.Name))
+	if err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	if !result.Requeue {
+		t.Error("expected Requeue=true after finalizer add; without it the reconciler stalls permanently (issue #329)")
+	}
+}
+
 // TestFinalizerNotDuplicatedIfPresent verifies that when the CR already has the
 // device-cleanup finalizer, Reconcile does not call r.Update (no metadata patch).
 func TestFinalizerNotDuplicatedIfPresent(t *testing.T) {


### PR DESCRIPTION
## Summary
- `LosantSync` reconciler stalls permanently after writing the `losant.io/device-cleanup` finalizer
- Root cause: `GenerationChangedPredicate` filters metadata-only watch events (finalizer writes don't bump `.metadata.generation`), and the controller returned `ctrl.Result{}` with no requeue — so no further reconcile was ever triggered
- Fix: explicitly return `ctrl.Result{Requeue: true}` after the `Update`, ensuring the reconciler re-enters immediately regardless of watch-event filtering

## Test plan
- [ ] `make test` passes (all existing controller tests green, including `TestFinalizerAddedOnFirstReconcile` and `TestFinalizerNotDuplicatedIfPresent`)
- [ ] Test-engineer to add a regression test asserting `result.Requeue == true` after the finalizer-add path

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)