### PR TITLE
feat(dev): add CONTAINER_TOOL variable and dev-deploy Makefile target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@v3
       - run: make test
-      - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:${{ github.ref_name }}
-      - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:latest
+      - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:${{ github.ref_name }} CONTAINER_TOOL=docker
+      - run: make docker-buildx IMG=ghcr.io/mak3r/losant-device:latest CONTAINER_TOOL=docker
       - name: Verify multi-arch manifest
         run: |
           MANIFEST=$(docker buildx imagetools inspect ghcr.io/mak3r/losant-device:${{ github.ref_name }})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 # Image URL to use for all building/pushing image targets
 IMG ?= controller:latest
 PLATFORMS ?= linux/arm64,linux/amd64
+# Container tool — override with CONTAINER_TOOL=docker if needed
+CONTAINER_TOOL ?= podman
+# Dev deploy settings — override DEV_IMG_TAG to use a different floating tag
+DEV_IMG_REPO ?= ghcr.io/mak3r/losant-device
+DEV_IMG_TAG ?= dev
+DEV_NAMESPACE ?= losant-system
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest
 ENVTEST_K8S_VERSION = 1.31.0
 
@@ -66,16 +72,16 @@ build: manifests generate fmt vet ## Build the manager binary to bin/manager
 
 .PHONY: docker-build
 docker-build: ## Build the container image (set IMG=<image>:<tag>)
-	docker build -t ${IMG} .
+	$(CONTAINER_TOOL) build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push the container image (set IMG=<image>:<tag>)
-	docker push ${IMG}
+	$(CONTAINER_TOOL) push ${IMG}
 
 .PHONY: docker-buildx
 docker-buildx: ## Build and push multi-arch image via buildx (set IMG=<image>:<tag>)
-	docker buildx create --use --name losant-builder || true
-	docker buildx build \
+	$(CONTAINER_TOOL) buildx create --use --name losant-builder || true
+	$(CONTAINER_TOOL) buildx build \
 	  --platform $(PLATFORMS) \
 	  --tag $(IMG) \
 	  --push \
@@ -103,6 +109,16 @@ deploy: manifests install ## Deploy controller to cluster, installing CRDs first
 .PHONY: undeploy
 undeploy: ## Remove the controller from the cluster
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+
+.PHONY: dev-deploy
+dev-deploy: ## Build, push :dev tag, and helm upgrade with pullPolicy=Always (set DEV_IMG_TAG to override)
+	$(CONTAINER_TOOL) build -t $(DEV_IMG_REPO):$(DEV_IMG_TAG) .
+	$(CONTAINER_TOOL) push $(DEV_IMG_REPO):$(DEV_IMG_TAG)
+	helm upgrade --install losant-device ./helm \
+	  --set controller.image.repository=$(DEV_IMG_REPO) \
+	  --set controller.image.tag=$(DEV_IMG_TAG) \
+	  --set controller.image.pullPolicy=Always \
+	  -n $(DEV_NAMESPACE) --create-namespace
 
 .PHONY: reset
 reset: ## Full teardown: undeploy operator, uninstall CRDs, delete losant-system namespace (idempotent)


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `docker` references in Makefile `docker-build`, `docker-push`, and `docker-buildx` targets with `$(CONTAINER_TOOL)` (defaults to `podman`)
- Adds `DEV_IMG_REPO`, `DEV_IMG_TAG`, `DEV_NAMESPACE` variables for dev workflow configuration
- Adds `dev-deploy` target: builds a floating `:dev` image, pushes to GHCR, and helm-upgrades the cluster — one-command path for iterative alpha testing
- Passes `CONTAINER_TOOL=docker` to `make docker-buildx` in `release.yml` so CI (GitHub Actions runners with Docker) continues to work correctly

Closes #333

## Test plan

- [ ] `make docker-build` uses `$(CONTAINER_TOOL)` — confirm with `CONTAINER_TOOL=echo make docker-build` (dry-run)
- [ ] `make dev-deploy DEV_IMG_TAG=my-feature` builds and pushes a named floating tag
- [ ] `make docker-buildx CONTAINER_TOOL=docker` works on GHA runner
- [ ] Release workflow `make docker-buildx` calls now include `CONTAINER_TOOL=docker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)