### PR TITLE
docs: data-validation guide, automated workflow deployment docs

### DIFF
--- a/docs/data-validation.md
+++ b/docs/data-validation.md
@@ -1,0 +1,246 @@
+# Data Validation — Confirming Metrics Reach Losant
+
+This guide walks through the runtime checks that confirm the `losant-device` operator is collecting cluster health data and forwarding it to Losant. Run each section in order; stop and investigate if any check fails before proceeding.
+
+---
+
+## Prerequisites
+
+- `kubectl` configured against the target cluster (`~/.kube/config` or `KUBECONFIG`)
+- The operator deployed in-cluster (see [setup guide](setup/README.md)); `make run` mode cannot reach the in-cluster GEA and will fail Step 3 onward
+- A `LosantSync` resource applied and at least one reconcile cycle completed
+
+---
+
+## 1. Kubernetes Resources Are Running
+
+All four components must be `Running` before any data can flow.
+
+### Controller pod
+
+```bash
+kubectl get pods -n losant-system -l app.kubernetes.io/name=losant-device
+```
+
+Expected: one pod in `Running` state with all containers `Ready`.
+
+### GEA pod
+
+```bash
+kubectl get pods -n losant-system -l app=losant-gea
+```
+
+Expected: one pod in `Running` state. If it is stuck in `Init:0/1`, the `losant-gea-credentials` Secret is missing or empty — see [Step 5](#5-gea-credentials-are-populated).
+
+### GEA Service
+
+```bash
+kubectl get svc -n losant-system losant-gea
+```
+
+Expected: a `ClusterIP` service with port `8080` listed.
+
+### LosantSync resource
+
+```bash
+kubectl get losantsync
+```
+
+Expected output columns include the cluster name, phase, GEA status, last sync time, and next sync time:
+
+```
+NAME        CLUSTER    PHASE    GEA    LAST SYNC   NEXT SYNC   AGE
+my-cluster  my-site    Active   True   2m          5m          10m
+```
+
+If `PHASE` is `Provisioning`, the first reconcile cycle has not completed yet — wait 30 seconds and re-run.
+If `PHASE` is `Degraded`, proceed to [Step 6](#6-check-controller-logs).
+
+---
+
+## 2. LosantSync Conditions Show All Green
+
+The `LosantSync` status block carries four conditions that map to the four reconcile steps. All must be `True` for data to flow end-to-end.
+
+```bash
+kubectl get losantsync <NAME> -o jsonpath='{.status.conditions}' | jq .
+```
+
+| Condition | What it means |
+|---|---|
+| `GEABootstrapped` | The controller created the `losant-gea-credentials` Secret and restarted the GEA pod |
+| `DevicesProvisioned` | All cluster and node devices exist in the Losant application |
+| `GEAReachable` | The last `POST /state` to the GEA returned HTTP 2xx |
+| `LastSyncSucceeded` | The full reconcile cycle (provisioning + reporting) completed without error |
+
+Expected: all four conditions show `status: "True"`.
+
+If any condition is `False`, the `message` field contains the exact error. Example:
+
+```bash
+kubectl get losantsync <NAME> -o jsonpath='{.status.conditions[?(@.type=="GEAReachable")].message}'
+```
+
+---
+
+## 3. GEA Is Accepting State Payloads
+
+The controller sends a JSON payload to `http://losant-gea:8080/state` on each reconcile. You can test this manually from a temporary pod:
+
+```bash
+kubectl run gea-probe --rm -it --image=curlimages/curl --restart=Never -n losant-system -- \
+  curl -s -o /dev/null -w "%{http_code}" \
+  -X POST http://losant-gea:8080/state \
+  -H "Content-Type: application/json" \
+  -d '{"deviceId":"test","data":{}}'
+```
+
+Expected: HTTP status `200`. Any `4xx` or `5xx` response, or a connection refused error, means the GEA is not ready — check the GEA pod logs (Step 4).
+
+---
+
+## 4. GEA Pod Logs Show MQTT Connection to Losant
+
+The GEA pod logs confirm whether it has established an MQTT connection to `broker.losant.com` and is forwarding buffered state data.
+
+```bash
+kubectl logs -n losant-system -l app=losant-gea --tail=100
+```
+
+**Signs the connection is established:**
+
+- Log line containing `Connected` or `MQTT connected` — confirms the GEA has authenticated with Losant
+- Log lines containing `Sending device state` or `state report` — confirms data is being forwarded
+- Absence of `MQTT disconnected` or `reconnecting` lines at the end of the log
+
+**Signs of a problem:**
+
+| Log message | Likely cause |
+|---|---|
+| `waiting for GEA credentials secret` | `losant-gea-credentials` Secret not yet populated — wait for bootstrap (Step 5) |
+| `MQTT connect failed` | Wrong `ACCESS_KEY` / `ACCESS_SECRET` in the Secret, or `broker.losant.com` unreachable |
+| `invalid device ID` | `DEVICE_ID` in the Secret does not match a device in the Losant application |
+| No output / pod restarting | Init container still waiting, or pod in CrashLoop — `kubectl describe pod` for details |
+
+---
+
+## 5. GEA Credentials Are Populated
+
+The `losant-gea-credentials` Secret contains the three values the GEA needs to authenticate with Losant. Check that all three are non-empty:
+
+```bash
+kubectl get secret losant-gea-credentials -n losant-system \
+  -o jsonpath='{.data}' | jq 'to_entries[] | {key: .key, empty: (.value | @base64d | length == 0)}'
+```
+
+Expected: `"empty": false` for `DEVICE_ID`, `ACCESS_KEY`, and `ACCESS_SECRET`.
+
+If any value is empty, the controller has not completed bootstrap yet. Check the `GEABootstrapped` condition (Step 2) and the controller logs (Step 6) for details.
+
+---
+
+## 6. Check Controller Logs for Reconcile Output
+
+The controller emits a log line for each reconcile step. A successful cycle looks like:
+
+```bash
+kubectl logs -n losant-system -l app.kubernetes.io/name=losant-device --tail=200
+```
+
+Key log lines in a healthy cycle (in order):
+
+| Log message | What it confirms |
+|---|---|
+| `sync due, starting provisioning and reporting` | A reconcile cycle started |
+| `GEA credentials provisioned` | Bootstrap completed (only on first run) |
+| `all devices confirmed in Losant` | Cluster and node devices exist in Losant |
+| `GEA accepted cluster state` | Controller successfully POSTed to the GEA |
+| `sync complete` | Full cycle succeeded; `nextSync` shows when the next one fires |
+
+**Error patterns to watch for:**
+
+| Log message | Meaning |
+|---|---|
+| `Losant ping failed` | Cannot reach `api.losant.com` — network or credential issue |
+| `failed to ensure cluster device` | API error creating/fetching the cluster Edge Compute device |
+| `GEA unreachable, will retry` | `POST /state` to the GEA failed — check GEA pod status |
+| `failed to ensure node device` | A node's peripheral device could not be provisioned |
+| `reconciliation suspended` | `LosantSync.spec.suspend` is `true` — no data is sent while suspended |
+
+---
+
+## 7. Verify Devices and Attributes Exist in Losant
+
+Log into the [Losant dashboard](https://app.losant.com) and navigate to your application.
+
+### Confirm the cluster Edge Compute device
+
+1. Go to **Devices** and search for the cluster name (value of `spec.clusterName` in the `LosantSync` resource)
+2. The device should exist as an **Edge Compute** device type
+3. Open the device and check **Recent Device State** — you should see a state report with these attributes:
+
+| Attribute | Description |
+|---|---|
+| `health_score` | Overall cluster health score (0–100) |
+| `health_status` | Human-readable status string |
+| `total_nodes` | Total node count |
+| `ready_nodes` | Nodes in Ready state |
+| `unhealthy_nodes` | Nodes not Ready |
+| `total_pods` | Total pod count across all namespaces |
+| `running_pods` | Pods in Running phase |
+| `failed_pods` | Pods in Failed phase |
+| `pending_pods` | Pods in Pending phase |
+| `crashloop_pods` | Pods in CrashLoopBackOff |
+| `degraded_pvcs` | PersistentVolumeClaims not in Bound state |
+| `coredns_healthy` | Whether CoreDNS pods are running |
+| `event_warnings` | Count of Warning-level cluster events |
+
+### Confirm node peripheral devices
+
+1. In **Devices**, search for the node hostnames (one device per k8s node)
+2. Each node device should show **Peripheral** type and be associated with the cluster Edge Compute device
+3. Open a node device and check **Recent Device State** — expected attributes:
+
+| Attribute | Description |
+|---|---|
+| `health_score` | Node health score (0–100) |
+| `health_status` | Human-readable status string |
+| `ready` | Node Ready condition |
+| `memory_pressure` | MemoryPressure condition |
+| `disk_pressure` | DiskPressure condition |
+| `pid_pressure` | PIDPressure condition |
+| `pod_count` | Total pods scheduled on this node |
+| `not_ready_pods` | Pods on this node that are not Ready |
+| `crashloop_pods` | CrashLoopBackOff pods on this node |
+| `cpu_request_pct` | CPU request utilisation (requests / allocatable) |
+| `mem_request_pct` | Memory request utilisation (requests / allocatable) |
+
+If devices exist but **Recent Device State** is empty, the GEA has not forwarded data yet — allow up to one full reconcile interval and recheck.
+
+---
+
+## 8. Quick End-to-End Checklist
+
+Run all checks in sequence and confirm each passes before moving to the next:
+
+```bash
+# 1. All pods running
+kubectl get pods -n losant-system
+
+# 2. LosantSync phase and GEA column are Active / True
+kubectl get losantsync
+
+# 3. All four conditions are True
+kubectl get losantsync <NAME> -o jsonpath='{.status.conditions[*].type} {.status.conditions[*].status}'
+
+# 4. Credentials populated
+kubectl get secret losant-gea-credentials -n losant-system -o jsonpath='{.data.DEVICE_ID}' | base64 -d | wc -c
+
+# 5. Controller completed a successful sync
+kubectl logs -n losant-system -l app.kubernetes.io/name=losant-device --tail=50 | grep "sync complete"
+
+# 6. GEA is connected (look for 'Connected' in GEA logs)
+kubectl logs -n losant-system -l app=losant-gea --tail=50 | grep -i "connect"
+```
+
+All six checks passing means data is flowing from the cluster to Losant.

--- a/docs/losant-setup.md
+++ b/docs/losant-setup.md
@@ -7,7 +7,7 @@
 | Old section | New location |
 |---|---|
 | Steps 1–3, 5–6 (Application, device, access key, API token, secrets) | [setup/1-losant-device-setup.md](setup/1-losant-device-setup.md) |
-| Step 4 (Edge Workflow) | [setup/3-losant-workflow-setup.md](setup/3-losant-workflow-setup.md) |
+| Step 4 (Edge Workflow) | [setup/4-losant-workflow.md](setup/4-losant-workflow.md) |
 | Steps 7–8 (Device Recipe, LosantSync CR) | [setup/4-operator-configuration.md](setup/4-operator-configuration.md) |
 | Troubleshooting | [setup/4-operator-configuration.md#troubleshooting](setup/4-operator-configuration.md#troubleshooting) |
 

--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -67,6 +67,8 @@ kubectl create secret generic losant-provisioning-credentials \
 
 > **Key name matters**: The controller reads the `api-token` key specifically. Any other key name causes a startup error.
 
+> **Required API token scopes**: The Application API Token must include `devices.*` and `deviceRecipes.*` for device provisioning. If you use `spec.workflowDeployments`, it must also include `edgeDeployments.release` — without this scope, the controller will enter `Degraded` phase with `ReleaseFailed` on the `WorkflowDeployed` condition. Configure scopes in the Losant UI under **Application → Access Keys → Edit**.
+
 ---
 
 ## Upgrade

--- a/docs/setup/4-losant-workflow.md
+++ b/docs/setup/4-losant-workflow.md
@@ -1,51 +1,93 @@
-# Step 4: Edge Workflow Setup
+# Step 4: Edge Workflow Deployment
 
-Create and deploy the Edge Workflow that receives state reports from the controller via the GEA.
+The operator automatically deploys Edge Workflows declared in `spec.workflowDeployments`. Once the LosantSync CR is applied and the cluster device is provisioned, the controller calls the Losant Edge Deployment API on each reconcile cycle to ensure the declared workflow versions are running on the GEA.
+
+> **Previous versions** required manually creating and deploying the Edge Workflow in the Losant UI. This step is now fully automated as of the `workflowDeployments` spec field.
+
+---
 
 ## Prerequisites
 
 - LosantSync CR at `Active` phase (see [Step 3](3-deploy.md))
-- Edge Compute device visible in **Application → Devices** (provisioned by the controller on first reconcile)
+- The Edge Workflow already exists in your Losant Application with at least one named version (create it in **Application → Workflows → Add Workflow → Edge Workflow**)
+- The Losant Application API Token has the `edgeDeployments.release` scope (see [Step 1](1-losant-application.md))
 
 ---
 
-## Wait for the Edge Compute device to appear Online
+## Declare workflows in the LosantSync spec
 
-Before creating the workflow, confirm the device is present and Online:
+Add a `workflowDeployments` list to your `LosantSync` manifest. Each entry declares one workflow version to keep deployed on the cluster's Edge Compute device:
 
-1. In Losant: **Application → Devices** — the cluster device should appear (named after `LosantSync.spec.clusterName`)
-2. Confirm the device shows **Online** status — this means the GEA has connected via MQTT
+```yaml
+apiVersion: losant.io/v1alpha1
+kind: LosantSync
+metadata:
+  name: prod-edge-01
+spec:
+  applicationID: "<application-id>"
+  provisioningSecretRef:
+    name: losant-provisioning-credentials
+    namespace: losant-system
+  clusterName: "prod-edge-01"
+  region: "us-west"
+  interval: "5m"
+  gea:
+    serviceRef: "losant-gea"
+    port: 8080
+  workflowDeployments:
+    - flowId: "<losant-workflow-id>"
+      version: "v1.0.0"
+```
 
-> If the device is not yet Online when you deploy the workflow, the deployment will fail with: *"Some of your selected devices have an agent version lower than the target version for this deployment."* Wait for the GEA pod to finish its MQTT handshake:
-> ```bash
-> kubectl logs deploy/losant-device-gea -n losant-system | grep "Connected to"
-> ```
-> Then retry the deployment.
+| Field | Description |
+|---|---|
+| `flowId` | Losant Edge Workflow ID (see [Finding a workflow ID](#finding-a-workflow-id) below) |
+| `version` | Named version string to deploy (must match an existing version in the Losant UI) |
+
+`workflowDeployments` is optional. If omitted, no workflow deployment is attempted and the `WorkflowDeployed` condition is not set.
 
 ---
 
-## Create the Edge Workflow
+## Finding a workflow ID
 
-1. In your Application → **Workflows** → **Add Workflow** → **Edge Workflow**
-2. Give the workflow a name (e.g., `k8s-state-receiver`)
-3. Under **Edge Devices**, select the Edge Compute device (visible in **Application → Devices** after first reconcile)
+In the Losant UI, the workflow ID appears in the browser URL when you open a workflow:
 
-> **Note on Device trigger blocks**: The workflow editor shows cloud-side trigger nodes labelled "Device" (command, connect, disconnect, startup). These fire on MQTT events from a cloud perspective and are **not** what you need here. You need an **HTTP Trigger** node — an edge-side trigger that listens for local HTTP requests on the GEA pod.
+```
+https://app.losant.com/applications/<appId>/flows/<flowId>/...
+```
+
+Copy the `<flowId>` segment. Alternatively, retrieve it via the Losant API:
+
+```bash
+curl -s -H "Authorization: Bearer <api-token>" \
+  "https://api.losant.com/applications/<appId>/flows?flowClass=edge" \
+  | jq '.items[] | {id: .id, name: .name}'
+```
 
 ---
 
-## Configure the HTTP Trigger node
+## Monitor deployment status
 
-4. In the workflow canvas, add an **HTTP Trigger** node
-5. Set the trigger path to `/state`
-6. Set the method to `POST`
-7. Leave the port at `8080` (must match `LosantSync.spec.gea.port`)
+The controller sets the `WorkflowDeployed` condition on the `LosantSync` status after processing workflow deployments:
+
+```bash
+kubectl get losantsync <NAME> -o jsonpath='{.status.conditions[?(@.type=="WorkflowDeployed")]}' | jq .
+```
+
+| Reason | Meaning |
+|---|---|
+| `Deployed` | All declared workflow versions are confirmed running on the GEA |
+| `DeploymentPending` | Release was sent to Losant; awaiting GEA confirmation (normal when GEA was just restarted or reconnected) |
+| `ReleaseFailed` | Losant API call to release the workflow failed; check controller logs |
+| `WorkflowNotFound` | A declared `flowId` does not exist in the Losant Application; verify the ID |
+
+`DeploymentPending` resolves automatically on the next reconcile cycle once the GEA confirms receipt of the deployment.
 
 ---
 
-## Payload format
+## Payload format reference
 
-The controller sends a separate POST for each device on every sync. The JSON body structure:
+The controller sends one HTTP POST per device (cluster + each node) on every sync. The GEA workflow receives these payloads via the HTTP trigger on port `8080`. The wire format:
 
 ```json
 {
@@ -55,9 +97,9 @@ The controller sends a separate POST for each device on every sync. The JSON bod
 }
 ```
 
-The `time` field is omitted when the controller does not supply an explicit timestamp; the GEA then applies its own clock.
+The `time` field is omitted when the controller does not supply an explicit timestamp; the GEA applies its own clock.
 
-**Cluster device payload** (`data` fields):
+**Cluster device attributes** (`data` fields):
 
 | Field | Type | Description |
 |---|---|---|
@@ -75,7 +117,7 @@ The `time` field is omitted when the controller does not supply an explicit time
 | `coredns_healthy` | boolean | `true` if all CoreDNS pods are Running |
 | `event_warnings` | number | Count of Warning-level events in the last observation window |
 
-**Node device payload** (`data` fields):
+**Node device attributes** (`data` fields):
 
 | Field | Type | Description |
 |---|---|---|
@@ -88,31 +130,8 @@ The `time` field is omitted when the controller does not supply an explicit time
 | `pod_count` | number | Total pods scheduled on this node |
 | `not_ready_pods` | number | Pods on this node not in Running phase |
 | `crashloop_pods` | number | Pods on this node in CrashLoopBackOff |
-
----
-
-## Route state to the correct device
-
-Because `deviceId` is included in every POST body, a single workflow handles both cluster and node state:
-
-8. From the HTTP Trigger, add a **Device: Set State** node
-9. Set the **Device** field to **Payload Path** and enter `data.body.deviceId`
-10. Set the **State** field to **Payload Path** and enter `data.body.data`
-11. Add an **HTTP Response** node after the Set State node:
-    - **Response Code**: `200`
-    - **Response Body Source**: **String Template**
-    - **Response Body Template**: `{}`
-
-    > The controller only checks the HTTP status code; the body is ignored. `{}` satisfies the required field.
-
----
-
-## Deploy the workflow
-
-12. Save the workflow
-13. Click **Deploy** to push it to the Edge Compute device
-
-Once deployed, the GEA will start accepting state POSTs from the controller on `http://losant-gea:8080/state`.
+| `cpu_request_pct` | number | CPU requests as a fraction of allocatable (0.0–1.0) |
+| `mem_request_pct` | number | Memory requests as a fraction of allocatable (0.0–1.0) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `docs/data-validation.md` — step-by-step guide for confirming metrics reach Losant (pods, conditions, GEA logs, credentials, Losant dashboard)
- Replace manual Edge Workflow creation/deployment steps in `docs/setup/4-losant-workflow.md` with documentation of the automated `spec.workflowDeployments` field, `WorkflowDeployed` condition, and `DeploymentPending` reason
- Add `edgeDeployments.release` API token scope note to `docs/setup/3-deploy.md`
- Fix broken redirect link in `docs/losant-setup.md` (pointed to non-existent file)

## Closes Issues

- Closes #338
- Closes #345

## Test plan

- [ ] `docs/data-validation.md` exists with kubectl commands that are syntactically correct
- [ ] `docs/setup/4-losant-workflow.md` contains no manual UI workflow creation steps
- [ ] `docs/setup/4-losant-workflow.md` documents `flowId`, `version`, `WorkflowDeployed` condition, and all four condition reasons
- [ ] `docs/setup/3-deploy.md` notes the `edgeDeployments.release` scope requirement
- [ ] `docs/losant-setup.md` redirect link for Step 4 resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)