### PR TITLE
feat(losant): add ReleaseWorkflow and GetEdgeDeployments to LosantClient

### DIFF
--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -45,6 +45,16 @@ const (
 	deviceClassNode = "peripheral"
 )
 
+// ErrWorkflowNotFound is returned by ReleaseWorkflow when the flowId does not exist in the application.
+var ErrWorkflowNotFound = fmt.Errorf("workflow not found")
+
+// EdgeDeploymentStatus holds the current and desired workflow versions for one Edge Workflow on a device.
+type EdgeDeploymentStatus struct {
+	FlowID         string
+	CurrentVersion string
+	DesiredVersion string
+}
+
 // LosantClient manages Losant device lifecycle via the REST provisioning API.
 type LosantClient interface {
 	// Ping verifies that the Application API Token is valid by calling
@@ -76,6 +86,14 @@ type LosantClient interface {
 	// DeleteDevice removes a device from Losant.
 	// Returns nil if the device does not exist (404 treated as success).
 	DeleteDevice(ctx context.Context, applicationID, deviceID string) error
+
+	// ReleaseWorkflow deploys the given workflow version to a specific Edge Compute device.
+	// Safe to call repeatedly; Losant updates desiredVersion idempotently.
+	// Returns ErrWorkflowNotFound if the flowId does not exist in the application.
+	ReleaseWorkflow(ctx context.Context, applicationID, deviceID, flowID, version string) error
+
+	// GetEdgeDeployments returns current and desired workflow versions for a specific device.
+	GetEdgeDeployments(ctx context.Context, applicationID, deviceID string) ([]EdgeDeploymentStatus, error)
 }
 
 // Device is a minimal Losant device representation sufficient for the provisioning workflow.
@@ -331,6 +349,53 @@ func (c *HTTPClient) DeleteDevice(ctx context.Context, applicationID, deviceID s
 		return nil
 	}
 	return err
+}
+
+// ReleaseWorkflow deploys a workflow version to an Edge Compute device via the Losant release API.
+// Returns ErrWorkflowNotFound when the API responds with 404 (flowId not found).
+func (c *HTTPClient) ReleaseWorkflow(ctx context.Context, applicationID, deviceID, flowID, version string) error {
+	payload := map[string]interface{}{
+		"flowId":    flowID,
+		"version":   version,
+		"deviceIds": []string{deviceID},
+	}
+	path := fmt.Sprintf("%s/applications/%s/edge/deployments/release", apiBase, applicationID)
+	_, err := c.doRequest(ctx, http.MethodPost, path, payload)
+	if err != nil && strings.Contains(err.Error(), "status 404") {
+		return ErrWorkflowNotFound
+	}
+	return err
+}
+
+// GetEdgeDeployments fetches current and desired workflow versions for a device.
+func (c *HTTPClient) GetEdgeDeployments(ctx context.Context, applicationID, deviceID string) ([]EdgeDeploymentStatus, error) {
+	path := fmt.Sprintf("%s/applications/%s/edge/deployments?deviceId=%s",
+		apiBase, applicationID, url.QueryEscape(deviceID))
+	body, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Items []struct {
+			FlowID         string `json:"flowId"`
+			CurrentVersion string `json:"currentVersion"`
+			DesiredVersion string `json:"desiredVersion"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("decode edge deployments response: %w", err)
+	}
+
+	out := make([]EdgeDeploymentStatus, len(result.Items))
+	for i, item := range result.Items {
+		out[i] = EdgeDeploymentStatus{
+			FlowID:         item.FlowID,
+			CurrentVersion: item.CurrentVersion,
+			DesiredVersion: item.DesiredVersion,
+		}
+	}
+	return out, nil
 }
 
 // clusterDeviceAttributes returns the standard attribute definitions for a cluster Edge Compute device.

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -19,6 +19,7 @@ package losant
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -685,5 +686,93 @@ func TestEnsureNodeDevice_Found_PatchHasAttributes(t *testing.T) {
 	attrs, ok := patchBody["attributes"].([]interface{})
 	if !ok || len(attrs) != 11 {
 		t.Errorf("PATCH body: expected 11 node attributes, got: %v", patchBody["attributes"])
+	}
+}
+
+// --- ReleaseWorkflow ---
+
+func TestReleaseWorkflow_Success(t *testing.T) {
+	var called bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /applications/app-123/edge/deployments/release", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		writeJSON(w, struct{}{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := newTestHTTPClient(srv.URL).ReleaseWorkflow(context.Background(), "app-123", "dev-edge-1", "flow-abc", "v1.0.0")
+	if err != nil {
+		t.Fatalf("ReleaseWorkflow: unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected POST /applications/app-123/edge/deployments/release to be called")
+	}
+}
+
+func TestReleaseWorkflow_WorkflowNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /applications/app-123/edge/deployments/release", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"type":"ResourceNotFound","message":"flow not found"}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	err := newTestHTTPClient(srv.URL).ReleaseWorkflow(context.Background(), "app-123", "dev-edge-1", "flow-missing", "v1.0.0")
+	if !errors.Is(err, ErrWorkflowNotFound) {
+		t.Fatalf("ReleaseWorkflow on 404: expected ErrWorkflowNotFound, got: %v", err)
+	}
+}
+
+// --- GetEdgeDeployments ---
+
+func TestGetEdgeDeployments_Success(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /applications/app-123/edge/deployments", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]interface{}{
+			"items": []map[string]interface{}{
+				{"flowId": "flow-1", "currentVersion": "v1.0.0", "desiredVersion": "v1.1.0"},
+				{"flowId": "flow-2", "currentVersion": "v2.0.0", "desiredVersion": "v2.0.0"},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	deployments, err := newTestHTTPClient(srv.URL).GetEdgeDeployments(context.Background(), "app-123", "dev-edge-1")
+	if err != nil {
+		t.Fatalf("GetEdgeDeployments: unexpected error: %v", err)
+	}
+	if len(deployments) != 2 {
+		t.Fatalf("GetEdgeDeployments: got %d items, want 2", len(deployments))
+	}
+	if deployments[0].FlowID != "flow-1" {
+		t.Errorf("deployments[0].FlowID: got %q, want %q", deployments[0].FlowID, "flow-1")
+	}
+	if deployments[0].CurrentVersion != "v1.0.0" {
+		t.Errorf("deployments[0].CurrentVersion: got %q, want %q", deployments[0].CurrentVersion, "v1.0.0")
+	}
+	if deployments[0].DesiredVersion != "v1.1.0" {
+		t.Errorf("deployments[0].DesiredVersion: got %q, want %q", deployments[0].DesiredVersion, "v1.1.0")
+	}
+	if deployments[1].FlowID != "flow-2" {
+		t.Errorf("deployments[1].FlowID: got %q, want %q", deployments[1].FlowID, "flow-2")
+	}
+}
+
+func TestGetEdgeDeployments_Empty(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /applications/app-123/edge/deployments", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]interface{}{"items": []interface{}{}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	deployments, err := newTestHTTPClient(srv.URL).GetEdgeDeployments(context.Background(), "app-123", "dev-edge-1")
+	if err != nil {
+		t.Fatalf("GetEdgeDeployments empty: unexpected error: %v", err)
+	}
+	if len(deployments) != 0 {
+		t.Errorf("GetEdgeDeployments empty: got %d items, want 0", len(deployments))
 	}
 }

--- a/internal/losant/mock_client.go
+++ b/internal/losant/mock_client.go
@@ -40,6 +40,8 @@ type MockClient struct {
 	CreateDeviceAccessKeyFunc func(ctx context.Context, applicationID, deviceID, name string) (string, string, string, error)
 	PatchDeviceAttributesFunc func(ctx context.Context, applicationID, deviceID string, attrs []DeviceAttribute) error
 	DeleteDeviceFunc          func(ctx context.Context, applicationID, deviceID string) error
+	ReleaseWorkflowFunc       func(ctx context.Context, applicationID, deviceID, flowID, version string) error
+	GetEdgeDeploymentsFunc    func(ctx context.Context, applicationID, deviceID string) ([]EdgeDeploymentStatus, error)
 
 	// Recorded calls — read after test assertions.
 	PingCalls                  []struct{}
@@ -50,6 +52,8 @@ type MockClient struct {
 	CreateDeviceAccessKeyCalls []CreateDeviceAccessKeyCall
 	PatchDeviceAttributesCalls []PatchDeviceAttributesCall
 	DeleteDeviceCalls          []DeleteDeviceCall
+	ReleaseWorkflowCalls       []ReleaseWorkflowCall
+	GetEdgeDeploymentsCalls    []GetEdgeDeploymentsCall
 }
 
 // EnsureClusterDeviceCall records one invocation of EnsureClusterDevice.
@@ -97,6 +101,20 @@ type DeleteDeviceCall struct {
 	DeviceID      string
 }
 
+// ReleaseWorkflowCall records one invocation of ReleaseWorkflow.
+type ReleaseWorkflowCall struct {
+	ApplicationID string
+	DeviceID      string
+	FlowID        string
+	Version       string
+}
+
+// GetEdgeDeploymentsCall records one invocation of GetEdgeDeployments.
+type GetEdgeDeploymentsCall struct {
+	ApplicationID string
+	DeviceID      string
+}
+
 // NewMockClient returns a MockClient with sensible defaults:
 // EnsureClusterDevice returns "mock-cluster-device-id"
 // EnsureNodeDevice returns "mock-node-<nodeName>"
@@ -134,6 +152,12 @@ func (m *MockClient) SetError(err error) {
 	m.DeleteDeviceFunc = func(_ context.Context, _, _ string) error {
 		return err
 	}
+	m.ReleaseWorkflowFunc = func(_ context.Context, _, _, _, _ string) error {
+		return err
+	}
+	m.GetEdgeDeploymentsFunc = func(_ context.Context, _, _ string) ([]EdgeDeploymentStatus, error) {
+		return nil, err
+	}
 }
 
 // CallCount returns the total number of calls recorded across all methods.
@@ -147,7 +171,9 @@ func (m *MockClient) CallCount() int {
 		len(m.GetDeviceCalls) +
 		len(m.CreateDeviceAccessKeyCalls) +
 		len(m.PatchDeviceAttributesCalls) +
-		len(m.DeleteDeviceCalls)
+		len(m.DeleteDeviceCalls) +
+		len(m.ReleaseWorkflowCalls) +
+		len(m.GetEdgeDeploymentsCalls)
 }
 
 // Reset clears all recorded calls and resets all HandlerFuncs to defaults.
@@ -162,6 +188,8 @@ func (m *MockClient) Reset() {
 	m.CreateDeviceAccessKeyFunc = nil
 	m.PatchDeviceAttributesFunc = nil
 	m.DeleteDeviceFunc = nil
+	m.ReleaseWorkflowFunc = nil
+	m.GetEdgeDeploymentsFunc = nil
 	m.PingCalls = nil
 	m.EnsureClusterDeviceCalls = nil
 	m.EnsureNodeDeviceCalls = nil
@@ -170,6 +198,8 @@ func (m *MockClient) Reset() {
 	m.CreateDeviceAccessKeyCalls = nil
 	m.PatchDeviceAttributesCalls = nil
 	m.DeleteDeviceCalls = nil
+	m.ReleaseWorkflowCalls = nil
+	m.GetEdgeDeploymentsCalls = nil
 }
 
 // Ping implements LosantClient.
@@ -292,4 +322,38 @@ func (m *MockClient) DeleteDevice(ctx context.Context, applicationID, deviceID s
 		return fn(ctx, applicationID, deviceID)
 	}
 	return nil
+}
+
+// ReleaseWorkflow implements LosantClient.
+func (m *MockClient) ReleaseWorkflow(ctx context.Context, applicationID, deviceID, flowID, version string) error {
+	m.mu.Lock()
+	m.ReleaseWorkflowCalls = append(m.ReleaseWorkflowCalls, ReleaseWorkflowCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+		FlowID:        flowID,
+		Version:       version,
+	})
+	fn := m.ReleaseWorkflowFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID, flowID, version)
+	}
+	return nil
+}
+
+// GetEdgeDeployments implements LosantClient.
+func (m *MockClient) GetEdgeDeployments(ctx context.Context, applicationID, deviceID string) ([]EdgeDeploymentStatus, error) {
+	m.mu.Lock()
+	m.GetEdgeDeploymentsCalls = append(m.GetEdgeDeploymentsCalls, GetEdgeDeploymentsCall{
+		ApplicationID: applicationID,
+		DeviceID:      deviceID,
+	})
+	fn := m.GetEdgeDeploymentsFunc
+	m.mu.Unlock()
+
+	if fn != nil {
+		return fn(ctx, applicationID, deviceID)
+	}
+	return nil, nil
 }


### PR DESCRIPTION
## Summary
- Adds `ErrWorkflowNotFound` sentinel error (returned when Losant API returns 404 for a flowId)
- Adds `EdgeDeploymentStatus` struct with `FlowID`, `CurrentVersion`, `DesiredVersion` fields
- Extends `LosantClient` interface with `ReleaseWorkflow` and `GetEdgeDeployments` methods
- Implements both on `HTTPClient`: `POST .../edge/deployments/release` and `GET .../edge/deployments?deviceId=...`
- Updates `MockClient` with handler funcs, call recorders, `SetError`, `CallCount`, and `Reset` coverage

Closes #343

## Test plan
- [x] `make test` passes (all packages green)
- [x] `git diff --exit-code config/rbac/role.yaml` shows no drift

**Note:** Unit tests for the new methods (successful release, 404 flowId, successful GET, empty GET) are to be written by the test-engineer per the pairing model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)