### PR TITLE
fix(api): change Next Sync printcolumn to type=string to fix <invalid> display

### DIFF
--- a/api/v1alpha1/losantsync_types.go
+++ b/api/v1alpha1/losantsync_types.go
@@ -148,7 +148,7 @@ type LosantSyncStatus struct {
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=`.status.phase`
 // +kubebuilder:printcolumn:name="GEA",type=string,JSONPath=`.status.conditions[?(@.type=="GEAReachable")].status`
 // +kubebuilder:printcolumn:name="Last Sync",type=date,JSONPath=`.status.lastSyncTime`
-// +kubebuilder:printcolumn:name="Next Sync",type=date,JSONPath=`.status.nextScheduledTime`
+// +kubebuilder:printcolumn:name="Next Sync",type=string,JSONPath=`.status.nextScheduledTime`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // LosantSync is the Schema for the losantsyncs API.


### PR DESCRIPTION
## Summary
- Changes the "Next Sync" `kubectl get losantsync` column from `type=date` to `type=string`
- `type=date` columns use `HumanDuration(time.Since(t))`, which returns `<invalid>` for future timestamps (negative durations)
- Since `nextScheduledTime` is always a future time, it always appeared as `<invalid>`
- After this fix, the column shows the RFC3339 absolute timestamp (e.g., `2026-05-05T10:15:00Z`)

Closes #340

## Test plan
- [x] `make manifests` runs cleanly; CRD base updated with `type: string`
- [x] `make test` passes (all packages green)
- [x] No RBAC drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)