### PR TITLE
fix(docs): replace invalid type/bug label with bug throughout CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 
 The merge manager is a gatekeeper, not a coder. When reviewing a PR it:
 
-1. Runs `make test` — if it fails, creates a GitHub issue labeled `persona/<owner>` and `type/bug`, comments on the PR with the issue link, and does NOT merge
+1. Runs `make test` — if it fails, creates a GitHub issue labeled `persona/<owner>` and `bug`, comments on the PR with the issue link, and does NOT merge
 2. Checks for open `type/security` issues on the branch — if any exist, blocks merge and creates a blocking issue
 3. If CI is green and no blockers exist, approves the PR and merges to `develop`
 4. Never edits source files, never force-pushes, never resolves conflicts directly
@@ -53,7 +53,7 @@ For releases: when `develop` is stable, the merge manager creates a PR from `dev
 The product designer is a trusted advisor and orchestrator, not an implementer. When invoked it:
 
 1. Designs system architecture and documents decisions in `.claude/plans/`
-2. Breaks work into GitHub issues with correct `persona/<name>`, `phase/<n>`, and `type/<task|bug|security>` labels
+2. Breaks work into GitHub issues with correct `persona/<name>`, `phase/<n>`, and one of `bug`, `type/task`, `type/security` labels
 3. Identifies dependencies between issues and personas; sets blocking relationships explicitly
 4. Advises on trade-offs and scope — proposes changes but never unilaterally implements them
 5. Reviews open issues and PRs to check alignment with architectural intent
@@ -70,8 +70,8 @@ The triage agent is an intake specialist, not an implementer. When invoked it:
 2. Asks clarifying questions until it has sufficient information to produce a complete report
 3. Determines the correct persona(s), phase, and type for each issue
 4. Presents a draft of every issue to the human for confirmation before creating anything
-5. Creates GitHub issues with correct `persona/<name>`, `phase/<n>`, and `type/<task|bug|security>` labels
-6. Creates multiple issues when a single incident spans multiple personas (e.g., a crash needs `persona/developer` + `type/bug` AND `persona/test-engineer` + `type/task`)
+5. Creates GitHub issues with correct `persona/<name>`, `phase/<n>`, and one of `bug`, `type/task`, `type/security` labels
+6. Creates multiple issues when a single incident spans multiple personas (e.g., a crash needs `persona/developer` + `bug` AND `persona/test-engineer` + `type/task`)
 7. Never commits code, never modifies any file, never creates `.claude/plans/` documents
 
 To invoke: run the `/triage` Claude Code skill.
@@ -80,12 +80,12 @@ To invoke: run the `/triage` Claude Code skill.
 
 | Symptom | Primary Issue | Secondary Issue |
 |---|---|---|
-| Code crash / broken functionality | `persona/developer` + `type/bug` | `persona/test-engineer` + `type/task` (if test coverage is missing) |
+| Code crash / broken functionality | `persona/developer` + `bug` | `persona/test-engineer` + `type/task` (if test coverage is missing) |
 | Usability confusion / unclear docs | `persona/docs` + `type/task` | — |
 | Security concern / RBAC / credential exposure | `persona/security` + `type/security` | — |
 | Architecture question / new feature design | `persona/product-designer` + `type/task` | — |
-| CI/CD failure / deployment issue / Helm chart bug | `persona/gitops-manager` + `type/bug` | — |
-| E2E / acceptance test failure | `persona/qa` + `type/bug` | — |
+| CI/CD failure / deployment issue / Helm chart bug | `persona/gitops-manager` + `bug` | — |
+| E2E / acceptance test failure | `persona/qa` + `bug` | — |
 
 ### Phase Determination
 
@@ -105,7 +105,7 @@ The test engineer does not have an independent feature branch. Instead:
 3. Both push to `feature/developer/<name>` until `make test` passes cleanly
 4. A single PR is opened containing both implementation and tests
 
-If the test engineer finds a bug, they open a GitHub issue labeled `persona/developer` and `type/bug`. They do not patch the implementation themselves.
+If the test engineer finds a bug, they open a GitHub issue labeled `persona/developer` and `bug`. They do not patch the implementation themselves.
 
 ## Docs Agent
 
@@ -128,7 +128,7 @@ Finishing your own file edits and committing is necessary but not sufficient. If
 After completing work that unblocks another persona, choose one of:
 
 1. **Same issue, next persona**: Remove your `persona/<name>` label from the issue, add `persona/<next>` label, and comment with what was done and exactly what the next persona must do.
-2. **New issue for distinct task**: Create a new issue labeled `persona/<next>`, `phase/<n>`, and `type/<task|bug|security>` with explicit instructions, then close your issue.
+2. **New issue for distinct task**: Create a new issue labeled `persona/<next>`, `phase/<n>`, and one of `bug`, `type/task`, `type/security` with explicit instructions, then close your issue.
 
 Without a handoff, the queue-based `watch-work` model breaks — agents only pick up issues labeled for their persona.
 
@@ -225,7 +225,7 @@ Changing these files has broad impact — coordinate with other personas before 
 When creating issues, always apply:
 - A `persona/<name>` label for the responsible persona
 - A `phase/<n>` label for the implementation phase
-- A `type/task`, `type/bug`, or `type/security` label
+- A `bug`, `type/task`, or `type/security` label
 
 The merge manager uses these labels to route notifications and gate PRs.
 

--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -147,6 +147,10 @@ spec:
   gea:
     serviceRef: "losant-gea"
     port: 8080
+  # workflowDeployments:          # Optional — declare Edge Workflows to keep deployed on the cluster GEA.
+  #   - flowId: "<workflow-id>"   # Losant workflow ID (from the Losant UI URL or API).
+  #     version: "v1.0.0"         # Must exactly match a saved version name in Losant.
+  #                                # See Step 4 for how to find or create a named version snapshot.
 ```
 
 ```bash

--- a/docs/setup/4-losant-workflow.md
+++ b/docs/setup/4-losant-workflow.md
@@ -42,7 +42,7 @@ spec:
 | Field | Description |
 |---|---|
 | `flowId` | Losant Edge Workflow ID (see [Finding a workflow ID](#finding-a-workflow-id) below) |
-| `version` | Named version string to deploy (must match an existing version in the Losant UI) |
+| `version` | Named version string to deploy — must exactly match a saved version name in Losant (see [Finding or creating a named workflow version](#finding-or-creating-a-named-workflow-version) below) |
 
 `workflowDeployments` is optional. If omitted, no workflow deployment is attempted and the `WorkflowDeployed` condition is not set.
 
@@ -66,6 +66,24 @@ curl -s -H "Authorization: Bearer <api-token>" \
 
 ---
 
+## Finding or creating a named workflow version
+
+Losant **auto-names version snapshots using timestamps** (e.g. `"2026-05-05T12-39-04"`) unless you create a snapshot with an explicit name. If you write `version: "v1.0.0"` in your CR but the workflow has no snapshot with that exact name, the controller returns `WorkflowDeployed=False` with reason `WorkflowNotFound` and a 404 in the logs.
+
+**To find or create a named version snapshot:**
+
+1. In the Losant UI, open your Application and select **Workflows** in the left side menu.
+2. Select the **Edge** tab in the center pane near the top.
+3. Click the Edge Workflow you want to deploy.
+4. Select the **Versions** tab on the right side of the editor window.
+5. The currently active version name is displayed at the top.
+6. Use the filter field to search for other existing saved versions.
+7. To create a new named version: click **Create Version**, enter a meaningful name (e.g. `v1.0.0`), and save. That name is now valid for the `version` field.
+
+> **Tip**: If you are using auto-generated timestamp versions (e.g. the default Losant snapshot name), copy the exact string shown in the Versions tab — including the `T` and dashes — and paste it into your CR.
+
+---
+
 ## Monitor deployment status
 
 The controller sets the `WorkflowDeployed` condition on the `LosantSync` status after processing workflow deployments:
@@ -79,7 +97,7 @@ kubectl get losantsync <NAME> -o jsonpath='{.status.conditions[?(@.type=="Workfl
 | `Deployed` | All declared workflow versions are confirmed running on the GEA |
 | `DeploymentPending` | Release was sent to Losant; awaiting GEA confirmation (normal when GEA was just restarted or reconnected) |
 | `ReleaseFailed` | Losant API call to release the workflow failed; check controller logs |
-| `WorkflowNotFound` | A declared `flowId` does not exist in the Losant Application; verify the ID |
+| `WorkflowNotFound` | The `flowId` does not exist, or the `version` string does not match any saved version snapshot in Losant; see [Finding or creating a named workflow version](#finding-or-creating-a-named-workflow-version) and [Troubleshooting](7-troubleshooting.md#workflowdeployedfalse--reason-workflownotfound) |
 
 `DeploymentPending` resolves automatically on the next reconcile cycle once the GEA confirms receipt of the deployment.
 

--- a/docs/setup/7-troubleshooting.md
+++ b/docs/setup/7-troubleshooting.md
@@ -228,6 +228,52 @@ kubectl patch losantsync <your-cr-name> --type=merge -p '{"spec":{"suspend":fals
 
 ---
 
+## `WorkflowDeployed=False` — Reason: `WorkflowNotFound`
+
+**Symptom**: `kubectl describe losantsync <your-cr-name>` shows:
+
+```
+Type:    WorkflowDeployed
+Status:  False
+Reason:  WorkflowNotFound
+Message: Workflow Version was not found
+```
+
+Controller logs include a line like:
+
+```
+error  workflow release failed  {"flowId": "...", "version": "v1.0.0", "status": 404}
+```
+
+**Cause**: The `version` value in `spec.workflowDeployments` does not match any saved version snapshot name in Losant. Losant auto-names version snapshots using timestamps (e.g. `"2026-05-05T12-39-04"`) unless you explicitly create a named version. Writing `v1.0.0` in the CR when no snapshot with that exact name exists produces this 404.
+
+The same `WorkflowNotFound` reason also appears when the `flowId` itself is wrong (the workflow does not exist in the Application at all).
+
+**Fix**:
+
+1. Open the Losant UI → **Application** → **Workflows** → **Edge** tab.
+2. Click the workflow referenced by `flowId`.
+3. Select the **Versions** tab on the right side of the editor.
+4. Check the list of saved version names. Copy the exact name you want to deploy (e.g. `"2026-05-05T12-39-04"` or `"v1.0.0"` if you created one).
+5. If no suitable named version exists, click **Create Version**, enter a name, and save.
+6. Update your `LosantSync` CR:
+
+   ```bash
+   kubectl patch losantsync <your-cr-name> --type=merge \
+     -p '{"spec":{"workflowDeployments":[{"flowId":"<id>","version":"<exact-version-name>"}]}}'
+   ```
+
+7. The controller reconciles on the next cycle. Confirm the condition clears:
+
+   ```bash
+   kubectl get losantsync <your-cr-name> \
+     -o jsonpath='{.status.conditions[?(@.type=="WorkflowDeployed")]}' | jq .
+   ```
+
+See [Step 4 — Edge Workflow](4-losant-workflow.md#finding-or-creating-a-named-workflow-version) for the full version UI walkthrough.
+
+---
+
 ## Next Step
 
 If bootstrap completes but data does not appear in Losant, see [Step 5 — Verify](5-verify.md).


### PR DESCRIPTION
## Summary
- Replaces all `type/bug` label references with `bug` to match the actual GitHub label name
- Normalizes the type-label notation from `type/<task|bug|security>` to explicit `bug`, `type/task`, `type/security`
- Affects routing tables, handoff instructions, merge-manager rules, and triage guidelines in CLAUDE.md

Closes #355

## Test plan
- [ ] Verify no `type/bug` remains in CLAUDE.md (`grep type/bug docs/CLAUDE.md` returns empty)
- [ ] Confirm `bug`, `type/task`, and `type/security` labels exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)