### PR TITLE
docs(api): document spec.tags fields in README, architecture, and setup guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,17 @@ Each cluster maps to:
 - One **Edge Compute device** (the GEA's identity) — cluster-level aggregate metrics
 - One **peripheral device** per k8s node — per-node CPU, memory, pod health
 
-Devices are tagged with `cluster_name`, `region`, `health_status`, and `rancher_url`, enabling Losant's dashboard context variables to filter across the fleet.
+Devices are tagged with `cluster_name`, `region`, `health_status`, and `rancher_url`, enabling Losant's dashboard context variables to filter across the fleet. The cluster device also accepts three optional identity tags (`manager`, `uid`, `gps`) from `spec.tags.*`.
+
+### `spec.tags` reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `spec.tags.manager` | string | No | URI of the management plane responsible for this cluster (e.g., Rancher URL). Not validated. |
+| `spec.tags.uid` | string | No | Stable unique identifier for this cluster across management systems. Not validated. |
+| `spec.tags.gps` | string | No | Physical location of this cluster, typically in decimal-degree format (e.g., `"37.7749,-122.4194"`). Not validated. |
+
+All three fields are optional and unvalidated. They appear on the cluster (Edge Compute) device only — not on node (peripheral) devices.
 
 ## Quick Start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,11 @@ region        = <spec.region>
 rancher_url   = <spec.rancherURL>
 health_status = healthy | degraded | critical   ← updated each sync
 k8s_version   = <serverVersion.GitVersion>
+
+# Optional identity tags from spec.tags.* (omitted if field is empty)
+manager       = <spec.tags.manager>   # management plane URI
+uid           = <spec.tags.uid>       # stable cluster identifier
+gps           = <spec.tags.gps>       # physical location coordinates
 ```
 
 **Attributes** (time-series state data):
@@ -118,6 +123,14 @@ spec:
     port: 8080
 
   deviceRecipeID: "xyz789"         # optional: bulk peripheral provisioning
+
+  # Optional identity tags forwarded to the Losant cluster device only.
+  # All sub-fields are unvalidated strings. Omit the entire block if unused.
+  tags:
+    manager: "https://rancher.example.com"  # management plane URI
+    uid: "prod-cluster-us-west-01"          # stable cluster identifier
+    gps: "37.7749,-122.4194"                # physical location coordinates
+
   suspend: false
 ```
 

--- a/docs/setup/3-deploy.md
+++ b/docs/setup/3-deploy.md
@@ -151,13 +151,17 @@ spec:
   #   - flowId: "<workflow-id>"   # Losant workflow ID (from the Losant UI URL or API).
   #     version: "v1.0.0"         # Must exactly match a saved version name in Losant.
   #                                # See Step 4 for how to find or create a named version snapshot.
+  # tags:                                        # Optional — identity tags applied to the Losant cluster device.
+  #   manager: "https://rancher.example.com"    # Management plane URI (not validated).
+  #   uid: "prod-cluster-us-west-01"            # Stable unique cluster identifier (not validated).
+  #   gps: "37.7749,-122.4194"                  # Physical location in decimal-degree format (not validated).
 ```
 
 ```bash
 kubectl apply -f losantsync.yaml
 ```
 
-> See [docs/architecture.md](../architecture.md#crd-losantsync) for the full CRD field reference including `cronSchedule`, `rancherURL`, and `deviceRecipeID`.
+> See [docs/architecture.md](../architecture.md#crd-losantsync) for the full CRD field reference including `cronSchedule`, `rancherURL`, `deviceRecipeID`, and `tags`.
 
 ---
 

--- a/docs/setup/4-losant-workflow.md
+++ b/docs/setup/4-losant-workflow.md
@@ -37,6 +37,10 @@ spec:
   workflowDeployments:
     - flowId: "<losant-workflow-id>"
       version: "v1.0.0"
+  # tags:                                        # Optional — identity tags applied to the Losant cluster device.
+  #   manager: "https://rancher.example.com"    # Management plane URI (not validated).
+  #   uid: "prod-cluster-us-west-01"            # Stable unique cluster identifier (not validated).
+  #   gps: "37.7749,-122.4194"                  # Physical location in decimal-degree format (not validated).
 ```
 
 | Field | Description |


### PR DESCRIPTION
## Summary

- Added `spec.tags` reference table to README.md describing `manager`, `uid`, and `gps` sub-fields
- Updated cluster device Tags section in `docs/architecture.md` to include the three optional identity tags from `spec.tags.*`
- Added commented-out `tags:` block to CRD spec example in `docs/architecture.md`
- Updated CR snippets in `docs/setup/3-deploy.md` and `docs/setup/4-losant-workflow.md` with commented `tags:` block
- Updated footnote in `3-deploy.md` to include `tags` in the field reference pointer

All three sub-fields (`manager`, `uid`, `gps`) are documented as optional, unvalidated, and cluster-device-only.

Closes #369

## Test plan

- [ ] Review README.md spec.tags reference table is accurate and readable
- [ ] Confirm architecture.md cluster device Tags block now shows `manager`, `uid`, `gps`
- [ ] Confirm setup/3-deploy.md and setup/4-losant-workflow.md CR snippets include commented `tags:` block
- [ ] Verify all links to architecture.md#crd-losantsync remain valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)