### PR TITLE
fix(helm): set GEA deployment strategy to Recreate

### DIFF
--- a/helm/templates/gea-deployment.yaml
+++ b/helm/templates/gea-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app.kubernetes.io/component: gea
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: losant-gea


### PR DESCRIPTION
## Summary

- Sets `strategy.type: Recreate` on the GEA deployment to prevent the LevelDB exclusive-lock deadlock during rolling updates
- The default `RollingUpdate` strategy starts the new pod before terminating the old one; LevelDB's file lock on `/data/losant-edge-agent-store.db` causes the new pod to immediately crash with `LEVEL_DATABASE_NOT_OPEN`
- `Recreate` ensures the old pod is fully terminated (releasing the lock) before the new pod starts

Closes #375

## Test plan

- [ ] Deploy GEA with an initial LosantSync CR; confirm it starts successfully
- [ ] Trigger a rollout (e.g., update image tag or delete the GEA pod); confirm single-pod transition with no CrashLoopBackOff
- [ ] Confirm `kubectl get deployment losant-device-gea -o yaml` shows `strategy.type: Recreate`
- [ ] Confirm no second pod is created during the rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)