### PR TITLE
fix(provisioner): reprovision GEA credentials when DEVICE_ID drifts from cluster device

### DIFF
--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -889,6 +889,55 @@ func conditionAbsent(conds []metav1.Condition, condType string) bool {
 
 // --- ensureWorkflowDeployments ---
 
+// TestDeleteRecreate_NewDeviceIDReprovisionsGEA covers the delete+recreate lifecycle regression
+// described in issue #374: when a LosantSync CR is deleted and recreated, the cluster gets a new
+// Losant device ID.  The losant-gea-credentials Secret from the old CR still holds the stale
+// DEVICE_ID.  Bootstrap must detect the mismatch and call CreateDeviceAccessKey with the new ID
+// so the GEA pod reconnects to the correct Losant device.
+func TestDeleteRecreate_NewDeviceIDReprovisionsGEA(t *testing.T) {
+	// Simulate a losant-gea-credentials Secret left behind by the deleted CR.
+	staleGEACreds := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "losant-gea-credentials", Namespace: "default"},
+		Data: map[string][]byte{
+			"DEVICE_ID":     []byte("old-cluster-device-id"),
+			"ACCESS_KEY":    []byte("old-key"),
+			"ACCESS_SECRET": []byte("old-secret"),
+		},
+	}
+
+	// Recreated CR has no status conditions (GEABootstrapped is absent → Bootstrap runs).
+	ls := baseLS("recreated")
+	ml := losant.NewMockClient()
+	ml.EnsureClusterDeviceFunc = func(_ context.Context, _ losantv1alpha1.LosantSyncSpec) (string, error) {
+		return "new-cluster-device-id", nil
+	}
+
+	c := buildClient(ls, credsSecret(), staleGEACreds)
+	r := newReconciler(c, ml, gea.NewMockClient(), monitor.NewHealthStore())
+
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+
+	if len(ml.CreateDeviceAccessKeyCalls) != 1 {
+		t.Errorf("expected 1 CreateDeviceAccessKey call (stale DEVICE_ID must be reprovisioned), got %d",
+			len(ml.CreateDeviceAccessKeyCalls))
+	}
+	call := ml.CreateDeviceAccessKeyCalls[0]
+	if call.DeviceID != "new-cluster-device-id" {
+		t.Errorf("CreateDeviceAccessKey DeviceID: got %q, want %q", call.DeviceID, "new-cluster-device-id")
+	}
+
+	var got corev1.Secret
+	if err := c.Get(context.Background(),
+		types.NamespacedName{Name: "losant-gea-credentials", Namespace: "default"}, &got); err != nil {
+		t.Fatalf("losant-gea-credentials not found after reprovision: %v", err)
+	}
+	if string(got.Data["DEVICE_ID"]) != "new-cluster-device-id" {
+		t.Errorf("DEVICE_ID in Secret: got %q, want %q", string(got.Data["DEVICE_ID"]), "new-cluster-device-id")
+	}
+}
+
 // TestWorkflowDeployments_EmptySpec verifies that when spec.WorkflowDeployments is
 // empty the reconciler does not set any WorkflowDeployed condition and still reaches Active.
 func TestWorkflowDeployments_EmptySpec(t *testing.T) {

--- a/internal/provisioner/bootstrap.go
+++ b/internal/provisioner/bootstrap.go
@@ -82,7 +82,8 @@ func (b *GEABootstrapper) Bootstrap(ctx context.Context, ls *losantv1alpha1.Losa
 	switch {
 	case getErr == nil:
 		d := existing.Data
-		if len(d["DEVICE_ID"]) > 0 && len(d["ACCESS_KEY"]) > 0 && len(d["ACCESS_SECRET"]) > 0 {
+		if len(d["DEVICE_ID"]) > 0 && len(d["ACCESS_KEY"]) > 0 && len(d["ACCESS_SECRET"]) > 0 &&
+			string(d["DEVICE_ID"]) == clusterDeviceID {
 			return nil
 		}
 	case errors.IsNotFound(getErr):

--- a/internal/provisioner/bootstrap_test.go
+++ b/internal/provisioner/bootstrap_test.go
@@ -138,12 +138,13 @@ func TestBootstrap_SecretIncomplete(t *testing.T) {
 	}
 }
 
-// TestBootstrap_SecretComplete verifies that Bootstrap is idempotent when all credentials exist.
+// TestBootstrap_SecretComplete verifies that Bootstrap is idempotent when all credentials exist
+// and DEVICE_ID matches the current clusterDeviceID.
 func TestBootstrap_SecretComplete(t *testing.T) {
 	complete := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: geaSecretName, Namespace: testNS},
 		Data: map[string][]byte{
-			"DEVICE_ID":     []byte("d"),
+			"DEVICE_ID":     []byte("device-789"),
 			"ACCESS_KEY":    []byte("k"),
 			"ACCESS_SECRET": []byte("s"),
 		},
@@ -161,6 +162,47 @@ func TestBootstrap_SecretComplete(t *testing.T) {
 
 	if len(mc.CreateDeviceAccessKeyCalls) != 0 {
 		t.Errorf("expected 0 CreateDeviceAccessKey calls, got %d", len(mc.CreateDeviceAccessKeyCalls))
+	}
+}
+
+// TestBootstrap_SecretStaleDeviceID verifies that Bootstrap reprovisions when the Secret's
+// DEVICE_ID does not match the current clusterDeviceID (delete+recreate lifecycle regression).
+func TestBootstrap_SecretStaleDeviceID(t *testing.T) {
+	stale := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: geaSecretName, Namespace: testNS},
+		Data: map[string][]byte{
+			"DEVICE_ID":     []byte("stale-device-id"),
+			"ACCESS_KEY":    []byte("old-key"),
+			"ACCESS_SECRET": []byte("old-secret"),
+		},
+	}
+
+	mc := losant.NewMockClient()
+	b := &provisioner.GEABootstrapper{
+		Client:       buildFakeClient(stale),
+		LosantClient: mc,
+	}
+
+	if err := b.Bootstrap(context.Background(), baseLS(), "device-789"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mc.CreateDeviceAccessKeyCalls) != 1 {
+		t.Errorf("expected 1 CreateDeviceAccessKey call, got %d", len(mc.CreateDeviceAccessKeyCalls))
+	}
+
+	var got corev1.Secret
+	if err := b.Client.Get(context.Background(), types.NamespacedName{Name: geaSecretName, Namespace: testNS}, &got); err != nil {
+		t.Fatalf("secret not found after reprovision: %v", err)
+	}
+	if string(got.Data["DEVICE_ID"]) != "device-789" {
+		t.Errorf("DEVICE_ID: got %q, want %q", string(got.Data["DEVICE_ID"]), "device-789")
+	}
+	if string(got.Data["ACCESS_KEY"]) != "mock-access-key" {
+		t.Errorf("ACCESS_KEY: got %q, want %q", string(got.Data["ACCESS_KEY"]), "mock-access-key")
+	}
+	if string(got.Data["ACCESS_SECRET"]) != "mock-access-secret" {
+		t.Errorf("ACCESS_SECRET: got %q, want %q", string(got.Data["ACCESS_SECRET"]), "mock-access-secret")
 	}
 }
 

--- a/internal/provisioner/bootstrap_test.go
+++ b/internal/provisioner/bootstrap_test.go
@@ -276,6 +276,58 @@ func TestBootstrap_SecretUpdateFails(t *testing.T) {
 	}
 }
 
+// TestBootstrap_StaleDeviceID_TriggersDeploymentRestart verifies that when the Secret holds stale
+// credentials (DEVICE_ID ≠ clusterDeviceID) and a GEA DeploymentRef is configured, Bootstrap
+// reprovisions the credentials AND patches the Deployment with a restartedAt annotation.
+// This covers the delete+recreate lifecycle: stale MQTT credentials would cause the GEA pod to
+// stay connected to the wrong Losant device, so the deployment restart forces reconnection.
+func TestBootstrap_StaleDeviceID_TriggersDeploymentRestart(t *testing.T) {
+	stale := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: geaSecretName, Namespace: testNS},
+		Data: map[string][]byte{
+			"DEVICE_ID":     []byte("old-cluster-id"),
+			"ACCESS_KEY":    []byte("old-key"),
+			"ACCESS_SECRET": []byte("old-secret"),
+		},
+	}
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "losant-gea", Namespace: testNS},
+	}
+
+	mc := losant.NewMockClient()
+	b := &provisioner.GEABootstrapper{
+		Client:       buildFakeClient(stale, dep),
+		LosantClient: mc,
+	}
+
+	ls := baseLS()
+	ls.Spec.GEA.DeploymentRef = "losant-gea"
+
+	if err := b.Bootstrap(context.Background(), ls, "new-cluster-id"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(mc.CreateDeviceAccessKeyCalls) != 1 {
+		t.Errorf("expected 1 CreateDeviceAccessKey call, got %d", len(mc.CreateDeviceAccessKeyCalls))
+	}
+
+	var gotSecret corev1.Secret
+	if err := b.Client.Get(context.Background(), types.NamespacedName{Name: geaSecretName, Namespace: testNS}, &gotSecret); err != nil {
+		t.Fatalf("secret not found after reprovision: %v", err)
+	}
+	if string(gotSecret.Data["DEVICE_ID"]) != "new-cluster-id" {
+		t.Errorf("DEVICE_ID: got %q, want %q", string(gotSecret.Data["DEVICE_ID"]), "new-cluster-id")
+	}
+
+	var gotDep appsv1.Deployment
+	if err := b.Client.Get(context.Background(), types.NamespacedName{Name: "losant-gea", Namespace: testNS}, &gotDep); err != nil {
+		t.Fatalf("deployment not found: %v", err)
+	}
+	if gotDep.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] == "" {
+		t.Errorf("expected restartedAt annotation on GEA deployment after stale-credential reprovision")
+	}
+}
+
 // TestBootstrap_DeploymentRestart verifies the GEA Deployment is patched with the restartedAt annotation.
 func TestBootstrap_DeploymentRestart(t *testing.T) {
 	dep := &appsv1.Deployment{


### PR DESCRIPTION
## Summary

- Fixes Bootstrap's early-return guard to also check that `DEVICE_ID` in the `losant-gea-credentials` Secret matches the current `clusterDeviceID`
- When IDs differ (delete+recreate scenario), falls through to create a new access key and trigger GEA rolling restart

## Root Cause

`Bootstrap` considered a Secret "complete" if all three fields (`DEVICE_ID`, `ACCESS_KEY`, `ACCESS_SECRET`) were non-empty, regardless of whether `DEVICE_ID` matched the current cluster device. After a CR deletion the controller deletes the Losant device (invalidating its key) but leaves the Secret intact. On re-apply the old Secret caused an immediate return — no new key was created and the GEA pod was never restarted, leaving it authenticating with a deleted key indefinitely.

## Change

`internal/provisioner/bootstrap.go`: added `string(d["DEVICE_ID"]) == clusterDeviceID` to the idempotency guard condition.

## Test Status

CI will fail until #378 (test-engineer) updates `TestBootstrap_SecretComplete` (which tested the old buggy behavior) and adds a regression test for the stale device ID path. Both test changes go on this branch.

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)