### PR TITLE
feat(helm): add RancherSession CRD, credentials Secret, and trigger Service

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -24,5 +24,11 @@ spec:
           env:
             - name: GEA_DEPLOYMENT_REF
               value: {{ if .Values.gea.deploymentRef }}{{ .Values.gea.deploymentRef | quote }}{{ else }}{{ printf "%s-gea" (include "losant-device.fullname" .) | quote }}{{ end }}
+          {{- if .Values.rancher.enabled }}
+          ports:
+            - name: trigger
+              containerPort: 9090
+              protocol: TCP
+          {{- end }}
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/helm/templates/rancher-credentials-secret.yaml
+++ b/helm/templates/rancher-credentials-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.rancher.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.rancher.credentialsSecret.name }}
+  namespace: {{ .Values.namespace.name }}
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+type: Opaque
+data: {}
+{{- end }}

--- a/helm/templates/ranchersession-crd.yaml
+++ b/helm/templates/ranchersession-crd.yaml
@@ -1,0 +1,192 @@
+{{- if .Values.rancher.enabled }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+    helm.sh/resource-policy: keep
+  name: ranchersessions.losant.io
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+spec:
+  group: losant.io
+  names:
+    kind: RancherSession
+    listKind: RancherSessionList
+    plural: ranchersessions
+    singular: ranchersession
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.rancherClusterID
+      name: Cluster ID
+      type: string
+    - jsonPath: .status.connectedAt
+      name: Connected
+      type: date
+    - jsonPath: .status.expiresAt
+      name: Expires
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          RancherSession is the Schema for the ranchersessions API.
+          It represents a single dynamic connect/disconnect lifecycle against a Rancher Manager instance.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RancherSessionSpec defines the desired state of RancherSession.
+            properties:
+              clusterDisplayName:
+                description: |-
+                  ClusterDisplayName is the human-readable name of the downstream Rancher cluster.
+                  Defaults to the CR name when omitted.
+                type: string
+              credentialsSecretRef:
+                description: |-
+                  CredentialsSecretRef references the Secret containing the Rancher API token
+                  and endpoint URL.
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              suspend:
+                default: false
+                description: Suspend disables all reconciliation when true.
+                type: boolean
+              ttlSeconds:
+                default: 3600
+                description: |-
+                  TTLSeconds is how long the Rancher registration session remains active before
+                  the controller disconnects and removes the cluster entry.
+                format: int64
+                type: integer
+            required:
+            - credentialsSecretRef
+            type: object
+          status:
+            description: RancherSessionStatus defines the observed state of RancherSession.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the resource's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              connectedAt:
+                description: ConnectedAt is the timestamp when the session reached
+                  the Connected phase.
+                format: date-time
+                type: string
+              expiresAt:
+                description: ExpiresAt is the timestamp when the TTL expires and the
+                  controller will disconnect.
+                format: date-time
+                type: string
+              lastTransitionMessage:
+                description: LastTransitionMessage is a human-readable message describing
+                  the last phase transition.
+                type: string
+              manifestApplied:
+                description: |-
+                  ManifestApplied indicates whether the Rancher import manifest has been applied
+                  to the downstream cluster.
+                type: boolean
+              phase:
+                description: Phase is the current lifecycle phase of this resource.
+                type: string
+              rancherClusterID:
+                description: |-
+                  RancherClusterID is the ID assigned by Rancher Manager to the downstream cluster
+                  after a successful CreateCluster call.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/helm/templates/trigger-service.yaml
+++ b/helm/templates/trigger-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rancher.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "losant-device.fullname" . }}-trigger
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "losant-device.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: trigger
+      port: 9090
+      targetPort: 9090
+      protocol: TCP
+{{- end }}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -87,6 +87,19 @@
         "create": { "type": "boolean" },
         "name": { "type": "string", "minLength": 1 }
       }
+    },
+    "rancher": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "credentialsSecret": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "minLength": 1 }
+          }
+        },
+        "defaultTTLSeconds": { "type": "integer", "minimum": 1 }
+      }
     }
   }
 }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -46,6 +46,13 @@ gea:
       accessKey: ""
       accessSecret: ""
 
+rancher:
+  # enabled: gates whether RancherSession CRD, rancher-credentials Secret, and trigger Service are installed
+  enabled: false
+  credentialsSecret:
+    name: rancher-credentials
+  defaultTTLSeconds: 3600
+
 rbac:
   create: true
 


### PR DESCRIPTION
## Summary

- Add `RancherSession` CRD to Helm chart, gated on `rancher.enabled` (default: `false`)
- Add `rancher-credentials` Secret placeholder with `helm.sh/resource-policy: keep` annotation so Helm upgrades do not overwrite customer credentials
- Add `rancher.enabled`, `rancher.credentialsSecret.name`, and `rancher.defaultTTLSeconds` to `values.yaml` and `values.schema.json`
- Add ClusterIP Service `<fullname>-trigger` on port 9090, gated on `rancher.enabled`
- Add `containerPort: 9090` to the controller manager Deployment when `rancher.enabled` is true

Closes #399, #403

## Test plan

- [ ] `helm template losant-device helm/ --set rancher.enabled=false` renders 10 documents (no Rancher resources)
- [ ] `helm template losant-device helm/ --set rancher.enabled=true` renders 13 documents (adds CRD, Secret, Service)
- [ ] RancherSession CRD has `helm.sh/resource-policy: keep` and matches generated schema
- [ ] rancher-credentials Secret has `helm.sh/resource-policy: keep` and empty `data: {}`
- [ ] trigger Service is ClusterIP only, port 9090
- [ ] Deployment has `containerPort: 9090` only when `rancher.enabled: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)