### PR TITLE
docs(rancher): add rancher-integration.md and architecture update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Remote Kubernetes clusters — especially k3s deployments at edge locations — 
 - **Cluster drill-down**: per-node metrics filtered by cluster or region
 - **Node detail**: time-series CPU, memory, pod health, and condition flags
 - **Rancher Manager link**: one click from any cluster view to the management UI
+- **Rancher dynamic connect/disconnect**: register and deregister clusters from Rancher Manager on demand, via Losant dashboard buttons or cloud workflows — without touching the cluster directly
 
 The operator runs inside each cluster and reports metrics to Losant on a configurable schedule (cron or interval), with resilience to intermittent network connectivity via the Losant Gateway Edge Agent (GEA).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,6 +39,44 @@ The Losant Gateway Edge Agent (`losant/edge-agent`) runs as a Deployment inside 
 └─────────────────────────────────────────────┘
 ```
 
+## Rancher Dynamic Connect/Disconnect
+
+The optional Rancher integration adds a second communication path to the controller: on-demand registration and deregistration of the edge cluster with a Rancher Manager instance, triggered via Losant device commands.
+
+```
+Losant cloud workflow
+  │  device command  { "action": "connect"|"disconnect", "ttlSeconds": N }
+  ▼
+GEA edge workflow (runs on cluster GEA pod)
+  │  HTTP POST  losant-device-trigger:9090/rancher
+  ▼
+Trigger receiver (port 9090, inside controller pod)
+  │  create / delete RancherSession CR
+  ▼
+RancherSessionReconciler
+  │  POST /v3/clusters  (create)  or  DELETE /v3/clusters/{id}  (disconnect)
+  ▼
+Rancher Manager  ←──────────────────────────────┐
+  │  returns import manifest URL                 │
+  ▼                                              │
+RancherSessionReconciler                         │
+  │  applies Rancher import manifest             │
+  ▼                                              │
+cattle-cluster-agent (cattle-system namespace) ──┘
+  registers cluster upstream
+```
+
+**Session lifecycle phases:** `Connecting` → `Connected` → `Disconnecting` → `Disconnected` (or `Failed` on error)
+
+**Disconnect paths (all produce the same cleanup):**
+1. Losant `disconnect` command → trigger server deletes `RancherSession` CR → reconciler finalizer removes Rancher cluster record and `cattle-system` namespace
+2. Rancher UI cluster deletion → reconciler detects 404 on next `GetCluster` poll → auto-cleans
+3. TTL expiry (`status.expiresAt`) → reconciler runs cleanup automatically
+
+The `rancher-credentials` Secret in `losant-system` provides `RANCHER_URL`, `RANCHER_TOKEN`, and `RANCHER_CA` to the controller. The trigger receiver Service (`losant-device-trigger`, ClusterIP port 9090) is only created when `rancher.enabled=true` in Helm values.
+
+See [docs/rancher-integration.md](rancher-integration.md) for the full operator guide.
+
 ## Losant Device Model
 
 Each k3s cluster maps to a set of Losant devices:

--- a/docs/calculating-health.md
+++ b/docs/calculating-health.md
@@ -164,6 +164,22 @@ If the actual score is 72 rather than 83, there are additional active factors no
 
 ---
 
+## Debug Tools
+
+Run `scripts/health-score.sh [NAMESPACE]` to print each deduction factor and compute the expected cluster health score without deploying additional tooling. Requires `kubectl` and `awk`.
+
+```bash
+# Default namespace: losant-system
+scripts/health-score.sh
+
+# Specify a namespace if your controller runs elsewhere
+scripts/health-score.sh my-namespace
+```
+
+The script mirrors the deduction algorithm in `internal/monitor/health_score.go` exactly, so the score it prints should match what the controller reports to Losant.
+
+---
+
 ## Score vs. Status: Not a Simple Equivalence
 
 Two clusters at score 75 can have very different operational urgency:

--- a/docs/rancher-integration.md
+++ b/docs/rancher-integration.md
@@ -1,0 +1,331 @@
+# Rancher Integration — Dynamic Cluster Connect/Disconnect
+
+This guide covers everything an operator needs to connect and disconnect edge clusters from Rancher Manager on demand, via Losant device commands.
+
+---
+
+## Overview
+
+The **Rancher dynamic connect/disconnect** feature lets you register an edge cluster with Rancher Manager through a Losant dashboard button or workflow trigger, and remove it again when done — without touching the edge cluster directly.
+
+### Architecture
+
+```
+Losant cloud workflow
+  ↓  device command  (action=connect|disconnect, ttlSeconds=N)
+GEA edge workflow (on cluster)
+  ↓  HTTP POST  (losant-device-trigger:9090/rancher)
+Trigger receiver server (inside controller pod)
+  ↓  creates / deletes RancherSession CR
+RancherSessionReconciler
+  ↓  Rancher v3 REST API  (POST/DELETE /v3/clusters)
+Rancher Manager
+  ↓  generates import manifest
+RancherSessionReconciler
+  ↓  applies manifest to cluster
+cattle-cluster-agent (in cattle-system namespace)
+  ↑→ Rancher Manager  (upstream registration complete)
+```
+
+### Guarantee
+
+Disconnecting a cluster from Rancher — by any method — removes only `cattle-system` and the Rancher cluster record. It does **not** affect the edge cluster's workloads, `losant-system`, LosantSync reporting, or any other namespace.
+
+---
+
+## Prerequisites
+
+Complete all steps in this section before using the connect/disconnect feature.
+
+### 1. Create the Rancher service account and API token
+
+In Rancher Manager, create a service account token scoped to the minimum permissions required by the controller.
+
+**Create the Global Role:**
+
+```yaml
+apiVersion: management.cattle.io/v3
+kind: GlobalRole
+metadata:
+  name: losant-device-controller
+rules:
+- apiGroups:
+  - management.cattle.io
+  resources:
+  - clusters
+  verbs:
+  - create
+  - get
+  - delete
+```
+
+**Bind the role to a service account user:**
+
+```yaml
+apiVersion: management.cattle.io/v3
+kind: GlobalRoleBinding
+metadata:
+  name: losant-device-controller-binding
+globalRoleName: losant-device-controller
+userName: <rancher-service-account-user>
+```
+
+Generate an API token for that user in **Rancher UI → User Settings → API Keys**. Record the token value — it is shown only once.
+
+> **Scope note:** This token is shared across all edge clusters managed by the controller. Per-cluster tokens are a future hardening option.
+
+### 2. Obtain the Rancher CA certificate
+
+The controller validates TLS against Rancher Manager's CA. Export the CA PEM from your Rancher deployment:
+
+```bash
+kubectl get secret tls-rancher-internal-ca \
+  -n cattle-system \
+  --context <rancher-cluster-context> \
+  -o jsonpath='{.data.cacerts\.pem}' | base64 -d > rancher-ca.pem
+```
+
+Adjust the secret name to match your Rancher installation.
+
+### 3. Create the `rancher-credentials` Secret
+
+Create the Secret in `losant-system` on the **edge cluster** (the cluster managed by the controller):
+
+```bash
+kubectl create secret generic rancher-credentials \
+  --namespace losant-system \
+  --from-literal=RANCHER_URL=https://rancher.example.com \
+  --from-literal=RANCHER_TOKEN=<token-from-step-1> \
+  --from-file=RANCHER_CA=rancher-ca.pem
+```
+
+The controller reads exactly three keys:
+
+| Key | Value |
+|---|---|
+| `RANCHER_URL` | Base URL of your Rancher Manager instance |
+| `RANCHER_TOKEN` | Service account Bearer token from Step 1 |
+| `RANCHER_CA` | PEM-encoded CA certificate from Step 2 |
+
+### 4. Enable Rancher support in Helm
+
+The trigger receiver Service and RancherSession CRD are gated by `rancher.enabled`. Set this in your Helm values or upgrade command:
+
+```bash
+helm upgrade losant-device \
+  oci://ghcr.io/mak3r/losant-device/charts/losant-device:<VERSION> \
+  --namespace losant-system \
+  --set rancher.enabled=true
+```
+
+Verify the trigger Service exists after upgrade:
+
+```bash
+kubectl get svc -n losant-system losant-device-trigger
+```
+
+---
+
+## Creating the Losant Cloud Workflow (Required)
+
+The connect/disconnect path does not function without a Losant cloud workflow that sends device commands to the cluster's Losant device.
+
+### Create the cloud workflow
+
+1. In **Losant UI → Application → Workflows → Add Workflow**, select **Cloud Workflow**.
+2. Name it (e.g., `rancher-connect-disconnect`).
+3. Add a trigger node — **Virtual Button** (for manual use) or **Dashboard Button** (for dashboard-triggered operations).
+4. Add a **Device Command** node after the trigger:
+   - **Device**: select the cluster's Edge Compute Losant device by name or via a context variable
+   - **Command Name**: `rancher`
+   - **Payload**: construct the payload from your trigger input:
+
+**Connect payload:**
+```json
+{
+  "action": "connect",
+  "ttlSeconds": 3600
+}
+```
+
+**Disconnect payload:**
+```json
+{
+  "action": "disconnect"
+}
+```
+
+5. Save and deploy the workflow.
+
+### Verify command delivery
+
+After triggering the workflow, confirm the command reached the device:
+
+1. In Losant UI, navigate to the cluster's Edge Compute device.
+2. Select **Debug** → **Command Log**.
+3. A `rancher` command entry with your payload should appear within a few seconds.
+
+---
+
+## Creating the GEA Edge Workflow (Required)
+
+The GEA edge workflow runs on the GEA pod inside the edge cluster. It receives the Losant device command and forwards it as an HTTP call to the controller's trigger server.
+
+### Create the edge workflow
+
+1. In **Losant UI → Application → Workflows → Add Workflow**, select **Edge Workflow**.
+2. Name it (e.g., `rancher-trigger`).
+3. Add a **Device Command** trigger node:
+   - **Command Name**: `rancher`
+4. Add an **HTTP** node after the trigger:
+   - **Method**: `POST`
+   - **URL**: `http://losant-device-trigger.losant-system.svc.cluster.local:9090/rancher`
+   - **Body**: the full device command payload (pass through from the trigger node output)
+   - **Content-Type**: `application/json`
+5. Save a named version (e.g., `v1.0.0`) — see [Finding or creating a named workflow version](setup/4-losant-workflow.md#finding-or-creating-a-named-workflow-version).
+
+### Deploy the edge workflow
+
+Add the workflow to your `LosantSync` CR under `spec.workflowDeployments`:
+
+```yaml
+spec:
+  workflowDeployments:
+    - flowId: "<rancher-trigger-workflow-id>"
+      version: "v1.0.0"
+```
+
+Apply the change and confirm deployment:
+
+```bash
+kubectl apply -f losantsync.yaml
+kubectl get losantsync <NAME> \
+  -o jsonpath='{.status.conditions[?(@.type=="WorkflowDeployed")]}' | jq .
+```
+
+The `WorkflowDeployed` condition should reach `Deployed`. See [Step 4: Edge Workflow Deployment](setup/4-losant-workflow.md) for full details on workflow deployment and troubleshooting.
+
+### Verify the edge workflow is active
+
+In Losant UI, navigate to the cluster's Edge Compute device → **Debug** tab. After deploying, the edge workflow appears in the active workflow list.
+
+---
+
+## Connect/Disconnect Operations
+
+### Connect a cluster
+
+Send a `connect` command via the Losant cloud workflow (virtual button, dashboard button, or API call). The command payload must include `action: connect`:
+
+```json
+{ "action": "connect", "ttlSeconds": 3600 }
+```
+
+The controller creates a `RancherSession` CR, calls the Rancher API to register the cluster, applies the Rancher import manifest, and waits for the `cattle-cluster-agent` to become ready. The full sequence takes 1–3 minutes on a typical k3s cluster.
+
+Monitor progress:
+
+```bash
+kubectl get ranchersession -n losant-system
+kubectl describe ranchersession <name> -n losant-system
+```
+
+The session transitions through phases: `Connecting` → `Connected`.
+
+### Disconnect via Losant workflow
+
+Send a `disconnect` command via the same cloud workflow:
+
+```json
+{ "action": "disconnect" }
+```
+
+The controller deletes the `RancherSession` CR, which triggers the finalizer cleanup: Rancher's cluster record is deleted and `cattle-system` is removed from the edge cluster.
+
+### Disconnect directly from the Rancher UI
+
+If you delete the cluster entry from the Rancher Manager UI, the controller detects the missing cluster record on the next reconcile cycle (`GetCluster` returns 404) and automatically cleans up the `cattle-system` namespace and removes the `RancherSession` CR.
+
+No action is required in Losant or on the edge cluster.
+
+### TTL-based automatic disconnect
+
+The `ttlSeconds` field in the connect payload controls how long the session remains active. When the TTL expires, the controller runs the same cleanup as a manual disconnect. The `status.expiresAt` field shows the exact expiry time:
+
+```bash
+kubectl get ranchersession -n losant-system \
+  -o jsonpath='{.items[0].status.expiresAt}'
+```
+
+The Losant Level 2 cluster dashboard surfaces `expiresAt` as an indicator tile when the cluster is connected.
+
+---
+
+## Troubleshooting
+
+### `RancherSession` stuck in `Connecting`
+
+The session remains in `Connecting` while the controller waits for `cattle-cluster-agent` to become Ready in `cattle-system`. Check the conditions:
+
+```bash
+kubectl describe ranchersession <name> -n losant-system
+```
+
+Common causes:
+- `cattle-cluster-agent` image pull failure — check image availability from the edge cluster's network
+- Rancher import manifest never fetched — check network connectivity from the controller pod to `RANCHER_URL`
+
+```bash
+kubectl get pods -n cattle-system
+kubectl describe deployment cattle-cluster-agent -n cattle-system
+```
+
+### Rancher API unreachable — `RancherAPIReachable=False`
+
+The `RancherAPIReachable` condition is set to `False` when the controller cannot reach `RANCHER_URL` or the API returns an error.
+
+```bash
+kubectl get ranchersession <name> -n losant-system \
+  -o jsonpath='{.status.conditions[?(@.type=="RancherAPIReachable")]}' | jq .
+```
+
+Check:
+1. `RANCHER_URL` in the `rancher-credentials` Secret is correct and reachable from the cluster
+2. `RANCHER_TOKEN` is valid and not expired
+3. `RANCHER_CA` matches the CA used by your Rancher Manager instance
+4. Network policies or firewall rules do not block outbound HTTPS from `losant-system`
+
+Verify the Secret keys are populated:
+
+```bash
+kubectl get secret rancher-credentials -n losant-system \
+  -o jsonpath='{.data}' | jq 'keys'
+```
+
+### Cluster not appearing in Rancher after connect
+
+If the `RancherSession` reaches `Connected` but the cluster does not appear as healthy in Rancher Manager:
+
+1. Check `cattle-cluster-agent` status:
+
+```bash
+kubectl get deployment cattle-cluster-agent -n cattle-system
+kubectl get pods -n cattle-system
+```
+
+2. Check for image pull errors — the import manifest references Rancher's agent image, which must be reachable from the edge cluster.
+
+3. Verify `status.manifestApplied` is `true`:
+
+```bash
+kubectl get ranchersession <name> -n losant-system \
+  -o jsonpath='{.status.manifestApplied}'
+```
+
+If `false`, the controller could not apply the import manifest. Check controller logs:
+
+```bash
+kubectl logs -n losant-system \
+  -l app.kubernetes.io/name=losant-device \
+  --since=10m | grep ranchersession
+```


### PR DESCRIPTION
## Summary

- Adds `docs/rancher-integration.md` — full prerequisite and operator guide for the Rancher dynamic cluster connect/disconnect feature (closes #404)
- Adds RancherSession data flow diagram to `docs/architecture.md`
- Adds Rancher dynamic connect to the README feature list

## Changes

- `docs/rancher-integration.md` (new): six sections covering overview, all prerequisites (Rancher service account, API token, `rancher-credentials` Secret, Helm gate), Losant cloud workflow setup, GEA edge workflow setup, connect/disconnect operations, and troubleshooting
- `docs/architecture.md`: new "Rancher Dynamic Connect/Disconnect" section with ASCII data flow diagram and session lifecycle summary
- `README.md`: adds Rancher dynamic connect/disconnect to the Overview feature list

## Test plan

- [ ] Verify `docs/rancher-integration.md` renders correctly in GitHub
- [ ] Verify all internal doc links resolve (`setup/4-losant-workflow.md`, `rancher-integration.md`)
- [ ] Confirm architecture diagram ASCII renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)