### PR TITLE
docs(watch-work): apply persona gate, blocked-issue resolution, and end-of-session report

### DIFF
--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -57,7 +57,7 @@ gh issue list \
   --label "persona/<persona-name>" \
   --json number,title,labels,updatedAt \
   --limit 25 \
-  --jq '.[] | select(.labels | map(.name) | contains(["type/freeze"]) | not) | "#\(.number)  \(.title)  \([.labels[].name] | join(","))  [updated \(.updatedAt[:10])]"'
+  --jq '.[] | "#\(.number)  \(.title)  \([.labels[].name] | join(","))  [updated \(.updatedAt[:10])]"'
 ```
 
 **Open PRs needing this persona's attention:**
@@ -85,31 +85,11 @@ gh issue list \
 >   )] | .[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  comments:\(.comments | length)"'
 > ```
 
-**Linked PRs for issues in your queue** — after the issue scan, for each issue number found (up to 5), check for linked PRs:
-```bash
-gh issue view <n>  # look for a "Pull requests:" section in the plain-text output
-```
-If a linked PR is listed, add it to the queue. These linked PRs are part of your work even if they are on a branch not matching your persona's prefix.
-
-Print the combined issue + PR results as a brief queue. Mark any issue carrying `status/blocked` with a `[BLOCKED]` tag in the queue display.
-
-**IMPORTANT: The queue display is an intermediate step, not a stopping point. Proceed immediately to Step 3 — do not pause, do not ask the user any questions.**
+Print the results as a brief queue, then proceed to Step 3.
 
 ---
 
 ## Step 3 — Pick the Highest-Priority Item
-
-**Skip any issue labeled `type/freeze`** — frozen issues are off-limits for all personas. If one appears in your scored list (e.g., via a PR association), skip it and move to the next item.
-
-**Issues labeled `status/blocked`** — do not skip automatically. For each blocked issue, run `gh issue view <n> --json body --jq '.body'` and extract the blocking issue number(s) referenced in the body. Then check each blocker:
-```bash
-gh issue view <blocking-n> --json state --jq '.state'
-```
-- If **all** referenced blocking issues are `closed`: the block is resolved. Remove the label autonomously (`gh issue edit <n> --remove-label "status/blocked"`) and treat the issue as unblocked for scoring purposes.
-- If **any** referenced blocking issue is still `open`: record this issue in the end-of-session report as a blocker (include the open blocking issue number and its owning persona's label), then skip it — do not work on it.
-- If no blocking issue number can be found in the body: skip the issue and record it in the end-of-session report as "status/blocked but no blocking issue identified — manual review needed."
-
-**Do not ask the user about blocked issues.** Resolve them autonomously using the rules above.
 
 **If persona is `merge-manager`**, use this priority order:
 
@@ -146,8 +126,8 @@ Do not announce the item and wait. Fetch details and begin immediately.
 For the selected item:
 
 1. **Fetch full details:**
-   - Issue: `gh issue view <n>` — scan the output for a "Pull requests:" section. If a linked PR appears, run `gh pr view <linked-pr-n> --comments` and treat that PR's branch as your working branch. Do not create a new branch or PR when an existing one already covers this issue.
-   - PR (if picked directly): `gh pr view <n> --comments`
+   - Issue: `gh issue view <n>`
+   - PR: `gh pr view <n> --comments`
 
 2. **Understand what's needed.** Read only the files required to complete the task — no broad codebase exploration.
 
@@ -205,44 +185,13 @@ For the selected item:
 
 After completing an item (or finding an empty queue):
 
-**Single-check mode** (no duration): stop and print the end-of-session report (format below).
-
-**Watch mode — session end** (`now >= end_time`): print the end-of-session report, then stop.
-
-### End-of-session report format
-
-```
-=== <persona> session complete @ <HH:MM> UTC ===
-
-COMPLETED (<N> items):
-  #<n>  <title>  — <one-line summary of what was done>  [<sha>]
-  (or: none)
-
-SKIPPED / BLOCKED (<M> items):
-  #<n>  <title>
-    Blocked by: #<blocking-n> (<title if known>) [persona/<owner>]
-    → Invoke: <owner-persona> to resolve
-  (or: none)
-
-NEXT STEPS:
-  → Invoke <persona-name>: <one line describing what they need to do>
-  (list one entry per handoff completed or per open blocker; omit if nothing to hand off)
-
-QUEUE EMPTY: <yes | no — if no, list remaining actionable items>
-===
-```
-
-Rules for the report:
-- **COMPLETED**: one line per item worked. Include the short SHA from `git log --oneline -1`.
-- **SKIPPED / BLOCKED**: one entry per issue that was in your queue but skipped due to an unresolved `status/blocked`, `type/freeze`, or out-of-scope label. For each, state the blocking issue number, its title (from `gh issue view`), and which persona label it carries so the user knows who to invoke.
-- **NEXT STEPS**: derive from (a) handoffs you executed during this session (re-labels or new issues created) and (b) blockers identified in SKIPPED. Name the persona, not the person. If you completed work that a merge-manager PR review is now needed for, always include `→ Invoke merge-manager: review PR #<n>`.
-- Do not print sections that are empty (omit SKIPPED if none, omit NEXT STEPS if none).
+**Single-check mode** (no duration): stop and print a summary of what was completed.
 
 **Watch mode:**
 - Is `now < end_time`?
   - **Yes and work was just completed**: immediately return to Step 2 to check for more work.
   - **Yes and queue was empty**: call `ScheduleWakeup` with `delaySeconds: 270`, `reason: "Polling for new work for <persona>"`, `prompt: "Resume watch-work: you are the <persona> persona. Continue from Step 2 — scan for open issues and PRs, pick the highest-priority item, do the work, then loop. Session ends at <end_time_iso>. Do not use slash commands; invoke the watch-work skill directly via the Skill tool with skill name 'watch-work' and args '<persona> until:<end_time_iso>'."`
-  - **No**: print the end-of-session report (see format above) and stop.
+  - **No**: print `Session complete for <persona>. Items completed this session: <N>.` and stop.
 
 ---
 
@@ -252,4 +201,4 @@ Rules for the report:
 2. `--jq` on every list call — only formatted strings reach context, not raw JSON.
 3. Read only files needed for the current task — no broad codebase exploration.
 4. Never quote issue or PR body verbatim unless it is directly relevant to a code decision.
-5. One issue-list call and one PR-list call per scan cycle, plus up to 5 `gh issue view` calls to discover linked PRs — no other exploration.
+5. One issue-list call and one PR-list call per scan cycle.

--- a/.claude/commands/watch-work.md
+++ b/.claude/commands/watch-work.md
@@ -57,7 +57,7 @@ gh issue list \
   --label "persona/<persona-name>" \
   --json number,title,labels,updatedAt \
   --limit 25 \
-  --jq '.[] | "#\(.number)  \(.title)  \([.labels[].name] | join(","))  [updated \(.updatedAt[:10])]"'
+  --jq '.[] | select(.labels | map(.name) | contains(["type/freeze"]) | not) | "#\(.number)  \(.title)  \([.labels[].name] | join(","))  [updated \(.updatedAt[:10])]"'
 ```
 
 **Open PRs needing this persona's attention:**
@@ -85,11 +85,31 @@ gh issue list \
 >   )] | .[] | "#\(.number)  \(.title)  [\(.headRefName)]  review:\(.reviewDecision // "PENDING")  comments:\(.comments | length)"'
 > ```
 
-Print the results as a brief queue, then proceed to Step 3.
+**Linked PRs for issues in your queue** — after the issue scan, for each issue number found (up to 5), check for linked PRs:
+```bash
+gh issue view <n>  # look for a "Pull requests:" section in the plain-text output
+```
+If a linked PR is listed, add it to the queue. These linked PRs are part of your work even if they are on a branch not matching your persona's prefix.
+
+Print the combined issue + PR results as a brief queue. Mark any issue carrying `status/blocked` with a `[BLOCKED]` tag in the queue display.
+
+**IMPORTANT: The queue display is an intermediate step, not a stopping point. Proceed immediately to Step 3 — do not pause, do not ask the user any questions.**
 
 ---
 
 ## Step 3 — Pick the Highest-Priority Item
+
+**Skip any issue labeled `type/freeze`** — frozen issues are off-limits for all personas. If one appears in your scored list (e.g., via a PR association), skip it and move to the next item.
+
+**Issues labeled `status/blocked`** — do not skip automatically. For each blocked issue, run `gh issue view <n> --json body --jq '.body'` and extract the blocking issue number(s) referenced in the body. Then check each blocker:
+```bash
+gh issue view <blocking-n> --json state --jq '.state'
+```
+- If **all** referenced blocking issues are `closed`: the block is resolved. Remove the label autonomously (`gh issue edit <n> --remove-label "status/blocked"`) and treat the issue as unblocked for scoring purposes.
+- If **any** referenced blocking issue is still `open`: record this issue in the end-of-session report as a blocker (include the open blocking issue number and its owning persona's label), then skip it — do not work on it.
+- If no blocking issue number can be found in the body: skip the issue and record it in the end-of-session report as "status/blocked but no blocking issue identified — manual review needed."
+
+**Do not ask the user about blocked issues.** Resolve them autonomously using the rules above.
 
 **If persona is `merge-manager`**, use this priority order:
 
@@ -126,8 +146,8 @@ Do not announce the item and wait. Fetch details and begin immediately.
 For the selected item:
 
 1. **Fetch full details:**
-   - Issue: `gh issue view <n>`
-   - PR: `gh pr view <n> --comments`
+   - Issue: `gh issue view <n>` — scan the output for a "Pull requests:" section. If a linked PR appears, run `gh pr view <linked-pr-n> --comments` and treat that PR's branch as your working branch. Do not create a new branch or PR when an existing one already covers this issue.
+   - PR (if picked directly): `gh pr view <n> --comments`
 
 2. **Understand what's needed.** Read only the files required to complete the task — no broad codebase exploration.
 
@@ -185,13 +205,44 @@ For the selected item:
 
 After completing an item (or finding an empty queue):
 
-**Single-check mode** (no duration): stop and print a summary of what was completed.
+**Single-check mode** (no duration): stop and print the end-of-session report (format below).
+
+**Watch mode — session end** (`now >= end_time`): print the end-of-session report, then stop.
+
+### End-of-session report format
+
+```
+=== <persona> session complete @ <HH:MM> UTC ===
+
+COMPLETED (<N> items):
+  #<n>  <title>  — <one-line summary of what was done>  [<sha>]
+  (or: none)
+
+SKIPPED / BLOCKED (<M> items):
+  #<n>  <title>
+    Blocked by: #<blocking-n> (<title if known>) [persona/<owner>]
+    → Invoke: <owner-persona> to resolve
+  (or: none)
+
+NEXT STEPS:
+  → Invoke <persona-name>: <one line describing what they need to do>
+  (list one entry per handoff completed or per open blocker; omit if nothing to hand off)
+
+QUEUE EMPTY: <yes | no — if no, list remaining actionable items>
+===
+```
+
+Rules for the report:
+- **COMPLETED**: one line per item worked. Include the short SHA from `git log --oneline -1`.
+- **SKIPPED / BLOCKED**: one entry per issue that was in your queue but skipped due to an unresolved `status/blocked`, `type/freeze`, or out-of-scope label. For each, state the blocking issue number, its title (from `gh issue view`), and which persona label it carries so the user knows who to invoke.
+- **NEXT STEPS**: derive from (a) handoffs you executed during this session (re-labels or new issues created) and (b) blockers identified in SKIPPED. Name the persona, not the person. If you completed work that a merge-manager PR review is now needed for, always include `→ Invoke merge-manager: review PR #<n>`.
+- Do not print sections that are empty (omit SKIPPED if none, omit NEXT STEPS if none).
 
 **Watch mode:**
 - Is `now < end_time`?
   - **Yes and work was just completed**: immediately return to Step 2 to check for more work.
   - **Yes and queue was empty**: call `ScheduleWakeup` with `delaySeconds: 270`, `reason: "Polling for new work for <persona>"`, `prompt: "Resume watch-work: you are the <persona> persona. Continue from Step 2 — scan for open issues and PRs, pick the highest-priority item, do the work, then loop. Session ends at <end_time_iso>. Do not use slash commands; invoke the watch-work skill directly via the Skill tool with skill name 'watch-work' and args '<persona> until:<end_time_iso>'."`
-  - **No**: print `Session complete for <persona>. Items completed this session: <N>.` and stop.
+  - **No**: print the end-of-session report (see format above) and stop.
 
 ---
 
@@ -201,4 +252,4 @@ After completing an item (or finding an empty queue):
 2. `--jq` on every list call — only formatted strings reach context, not raw JSON.
 3. Read only files needed for the current task — no broad codebase exploration.
 4. Never quote issue or PR body verbatim unless it is directly relevant to a code decision.
-5. One issue-list call and one PR-list call per scan cycle.
+5. One issue-list call and one PR-list call per scan cycle, plus up to 5 `gh issue view` calls to discover linked PRs — no other exploration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Every piece of work is owned by exactly one persona. A persona only modifies fil
 | **security** | `persona/security` | `config/rbac/**`, security CI steps in `.github/workflows/**`, secret handling review |
 | **qa** | `persona/qa` | `test/e2e/**`, `docs/acceptance-criteria.md`, `docs/runbook.md` |
 | **gitops-manager** | `persona/gitops-manager` | `helm/**`, `config/**` (except `config/rbac/` which is security), `.github/workflows/**`, `Makefile` |
-| **docs** | `persona/docs` | `docs/**`, `README.md`, `CLAUDE.md`, inline `// +kubebuilder:` marker comments |
+| **docs** | `persona/docs` | `docs/**`, `README.md`, `CLAUDE.md`, `.claude/commands/**`, inline `// +kubebuilder:` marker comments |
 | **merge-manager** | — (no commits) | Creates GitHub issues and PR comments only |
 | **product-designer** | `persona/product-designer` | `.claude/plans/**`, GitHub Issues (create only), `docs/architecture.md` (joint with docs) |
 | **triage** | — (no commits) | Creates GitHub issues only; conducts human intake interview |


### PR DESCRIPTION
## Summary

- **Bug fix**: personas were stopping after printing the queue in Step 2 instead of proceeding — added an explicit bold gate after the queue display
- **Bug fix**: `status/blocked` issues triggered user questions (violating autonomous-operation rules) — personas now check whether the referenced blocking issue is closed and remove the label autonomously
- **Feature**: structured end-of-session report replaces the terse item-count line; includes completed items with SHAs, skipped/blocked items with owning persona, and a NEXT STEPS section
- **Fix**: `type/freeze` issues now filtered from the issue-list query so they never enter the scored queue
- **Fix**: linked-PR discovery added per issue (up to 5 `gh issue view` calls per scan cycle) so personas pick up work already tracked in open PRs
- **Scope fix**: `.claude/commands/**` explicitly assigned to docs persona in CLAUDE.md, resolving the ownership ambiguity that caused PR #424 (gitops-manager) to be created and later blocked

Closes #423

## What changed

- `.claude/commands/watch-work.md`: 59 lines changed
- `CLAUDE.md`: docs persona scope updated to include `.claude/commands/**`

## Commit

`d81f823` docs(watch-work): apply persona gate, blocked-issue resolution, and end-of-session report

## Test plan

- [ ] Run `/watch-work qa` (or any persona) with a single actionable issue — verify the persona proceeds past the queue display and works the issue without pausing
- [ ] Run `/watch-work <persona>` with a `status/blocked` issue whose blocker is closed — verify the label is removed and the issue is worked without prompting the user
- [ ] Run `/watch-work <persona>` with a `status/blocked` issue whose blocker is still open — verify the issue is skipped and appears in SKIPPED/BLOCKED with the correct owning persona named
- [ ] Verify end-of-session report includes COMPLETED, SKIPPED/BLOCKED, and NEXT STEPS sections appropriately
- [ ] Verify `type/freeze` issues do not appear in the scored queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)