### PR TITLE
feat(security): approve Rancher import manifest RBAC permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -22,6 +31,7 @@ rules:
   - create
   - delete
   - get
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -40,13 +50,23 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - patch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
+  - create
   - get
   - list
   - patch
@@ -93,3 +113,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - patch


### PR DESCRIPTION
## Summary

Approves minimum RBAC permissions required for `RancherSessionReconciler` to apply a Rancher v3 import manifest via server-side apply (`client.Apply` + `ForceOwnership`).

**New rules approved:**
- `rbac.authorization.k8s.io` / `clusterrolebindings, clusterroles`: `create, get, patch` — SSA of Rancher proxy ClusterRole and agent ClusterRoleBinding
- `core` / `configmaps, serviceaccounts`: `create, get, patch` — cattle-system resources in the Rancher manifest
- `apps` / `daemonsets`: `create, get, patch` — cattle-node-agent DaemonSet

**Extended rules:**
- `core/namespaces`: added `patch` — SSA requires patch, not just create
- `core/secrets`: added `patch` — SSA requires patch for existing secrets
- `apps/deployments`: added `create` — cattle-cluster-agent Deployment may not exist yet

**Explicitly NOT approved:**
- `escalate` on clusterroles — bypasses Kubernetes RBAC privilege escalation prevention; if `proxy-clusterrole-kubeapiserver` SSA fails without it, open a new `persona/security` + `type/security` issue
- `bind` on clusterrolebindings — same blast-radius concern
- Node subresource grants (`nodes/log`, `nodes/metrics`, etc.) — these belong to the cattle-cluster-agent identity, not the controller SA

**Blast radius note:** `configmaps` and `serviceaccounts` are in the ClusterRole (all namespaces). A follow-up should scope these to `cattle-system` via a separate Role+RoleBinding.

Closes #432

## Test plan
- [ ] Developer adds matching `// +kubebuilder:rbac` markers in `ranchersession_controller.go`
- [ ] `make manifests && git diff --exit-code config/rbac/role.yaml` passes (no drift)
- [ ] CI `manifest-drift` job passes on merge to `develop`
- [ ] Integration test: `RancherSession` successfully applies Rancher import manifest without RBAC errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)