### PR TITLE
feat(ranchersession): add kubebuilder RBAC markers for Rancher import manifest permissions

### DIFF
--- a/internal/controller/ranchersession_controller.go
+++ b/internal/controller/ranchersession_controller.go
@@ -56,10 +56,16 @@ const (
 	rancherConditionAPIReachable = "RancherAPIReachable"
 )
 
-// +kubebuilder:rbac:groups=losant.io,resources=ranchersessions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=losant.io,resources=ranchersessions/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create;delete
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;patch
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;patch
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;get;patch
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=create;delete;get;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;get;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups=losant.io,resources=ranchersessions,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=losant.io,resources=ranchersessions/status,verbs=get;patch;update
 
 // RancherSessionReconciler reconciles RancherSession objects.
 type RancherSessionReconciler struct {


### PR DESCRIPTION
## Summary

- Replaces the minimal `// +kubebuilder:rbac` markers in `ranchersession_controller.go` with the full set approved by the security persona in #432 and committed to `role.yaml` in PR #434
- Adds markers for `rbac.authorization.k8s.io/{clusterroles,clusterrolebindings}`, `core/{configmaps,serviceaccounts,namespaces,secrets}`, `apps/{daemonsets,deployments}`
- `make manifests && git diff --exit-code config/rbac/role.yaml` passes with zero drift
- `make test` passes (all packages green)

Closes #436

## Test plan
- [x] `make manifests && git diff --exit-code config/rbac/role.yaml` — exit 0 (zero drift)
- [x] `make test` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)