### PR TITLE
security(rbac): add escalate and bind verbs on clusterroles for Rancher import

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -113,11 +113,38 @@ rules:
   - patch
   - update
   - watch
+# RancherSessionReconciler applies Rancher cluster import manifests via server-side
+# apply (kubectl apply -f <registration-url>). Rancher import manifests contain
+# ClusterRoles (e.g. proxy-clusterrole-kubeapiserver) and ClusterRoleBindings with
+# permissions the controller SA does not itself hold.
+#
+# escalate: bypasses Kubernetes privilege-escalation prevention so the controller can
+#   create/patch ClusterRoles whose rules exceed its own permissions. Without this,
+#   Kubernetes rejects the apply even when create+patch verbs are granted.
+# bind: allows creating ClusterRoleBindings that reference ClusterRoles the SA does
+#   not fully hold. Without this, binding the imported ClusterRoles is rejected.
+#
+# This is the expected security posture for a Rancher import automation controller —
+# equivalent to a cluster operator running kubectl apply -f <registration-url> with
+# cluster-admin credentials. The Rancher project itself uses cluster-admin for entities
+# that automate downstream cluster registration.
+#
+# Accepted risk: the trigger server (internal/trigger/server.go) is ClusterIP-only
+# with no bearer-token auth; auth hardening is tracked as a future task in issue #407.
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  - create
+  - escalate
+  - get
+  - patch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - clusterroles
   verbs:
   - create
   - get


### PR DESCRIPTION
## Summary

- Adds `escalate` verb on `clusterroles` so the RancherSessionReconciler can server-side-apply Rancher import ClusterRoles whose rules exceed the controller SA's own permissions (Kubernetes privilege-escalation prevention bypass — the standard mechanism for this use case)
- Adds `bind` verb on `clusterroles` so the controller can create ClusterRoleBindings that reference the imported ClusterRoles without holding every permission in them
- Splits the combined `clusterroles`+`clusterrolebindings` rule into two separate rules so `escalate`/`bind` apply only to `clusterroles` (where needed)
- Adds inline YAML comments documenting the accepted security posture and the trigger-server auth risk (issue #407)

Resolves #457. References #454. Unblocks #455.

## Security rationale

Without `escalate`, `create`/`patch` on a ClusterRole fails when that role's rules exceed the applier's permissions — even with the verb grant. Without `bind`, creating a ClusterRoleBinding that references such a role is likewise rejected. These are the minimum additional verbs required; no other changes were made.

This aligns with Rancher's own trust model: the Rancher project uses cluster-admin for entities that automate downstream cluster registration. The controller's permission set is narrower (targeted RBAC verbs only, no cluster-admin).

The trigger server's lack of authentication is an accepted risk documented inline and tracked in issue #407; the server is ClusterIP-only.

## Test plan

- [ ] `make manifests && git diff --exit-code config/rbac/role.yaml` passes once the developer adds matching `// +kubebuilder:rbac` markers in `ranchersession_controller.go`
- [ ] CI manifest-drift job passes after developer markers are in place
- [ ] Helm RBAC fix (#455) mirrors these verbs in `helm/templates/clusterrole.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)