### PR TITLE
fix(ranchersession): add escalate and bind kubebuilder markers on clusterroles

### DIFF
--- a/internal/controller/ranchersession_controller.go
+++ b/internal/controller/ranchersession_controller.go
@@ -56,7 +56,7 @@ const (
 	rancherConditionAPIReachable = "RancherAPIReachable"
 )
 
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create;get;patch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind;create;escalate;get;patch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;patch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;get;patch


### PR DESCRIPTION
## Summary

- Adds `bind` and `escalate` verbs to the `clusterroles` `+kubebuilder:rbac` marker in `ranchersession_controller.go`
- Keeps `clusterrolebindings` marker unchanged (`create;get;patch` — no escalate/bind, matching role.yaml)
- These verbs were security-approved in issue #457 (closed) and committed to `role.yaml` via PR #459 (merged)

Closes #458

## ⚠️ CI Note — manifest-drift

The `manifest-drift` CI job will fail until issue #460 is resolved by the security persona. PR #459 added manual YAML comments to `config/rbac/role.yaml` that controller-gen strips on regeneration, producing a cosmetic diff (comments removed, rule order changed) even though the permissions are identical. This is a pre-existing issue with PR #459's format, not introduced by these marker changes.

Do **not** merge until #460 is resolved and `make manifests && git diff --exit-code config/rbac/role.yaml` passes cleanly.

## Test plan

- [x] `make test` — all packages pass
- [ ] `make manifests && git diff --exit-code config/rbac/role.yaml` — blocked by #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)