### PR TITLE
fix(rbac): remove controller-gen-incompatible comments and fix rule order

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -113,24 +113,14 @@ rules:
   - patch
   - update
   - watch
-# RancherSessionReconciler applies Rancher cluster import manifests via server-side
-# apply (kubectl apply -f <registration-url>). Rancher import manifests contain
-# ClusterRoles (e.g. proxy-clusterrole-kubeapiserver) and ClusterRoleBindings with
-# permissions the controller SA does not itself hold.
-#
-# escalate: bypasses Kubernetes privilege-escalation prevention so the controller can
-#   create/patch ClusterRoles whose rules exceed its own permissions. Without this,
-#   Kubernetes rejects the apply even when create+patch verbs are granted.
-# bind: allows creating ClusterRoleBindings that reference ClusterRoles the SA does
-#   not fully hold. Without this, binding the imported ClusterRoles is rejected.
-#
-# This is the expected security posture for a Rancher import automation controller —
-# equivalent to a cluster operator running kubectl apply -f <registration-url> with
-# cluster-admin credentials. The Rancher project itself uses cluster-admin for entities
-# that automate downstream cluster registration.
-#
-# Accepted risk: the trigger server (internal/trigger/server.go) is ClusterIP-only
-# with no bearer-token auth; auth hardening is tracked as a future task in issue #407.
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - patch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -139,13 +129,5 @@ rules:
   - bind
   - create
   - escalate
-  - get
-  - patch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  verbs:
-  - create
   - get
   - patch


### PR DESCRIPTION
## Summary

- Removes 18-line inline YAML comment block from `config/rbac/role.yaml` that controller-gen strips on every `make manifests` run
- Reorders `clusterrolebindings` before `clusterroles` to match controller-gen's canonical alphabetical output
- All RBAC permissions (bind, create, escalate, get, patch on clusterroles; create, get, patch on clusterrolebindings) are **unchanged**

## Why

PR #459 added documentation comments directly in the controller-gen output zone of `role.yaml`. Because controller-gen strips all YAML comments when regenerating the file, every subsequent `make manifests` run produced a non-empty diff, causing the `manifest-drift` CI job to fail. This was blocking PR #461 (developer adding the matching `// +kubebuilder:rbac` markers) from passing CI.

The security rationale is preserved in PR #459's commit message and issue #457.

## Test plan

- [ ] `make manifests && git diff --exit-code config/rbac/role.yaml` — must pass on the feature branch after #461 merges
- [ ] `manifest-drift` CI job passes on PR #461

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)