### PR TITLE
fix(helm): add bind and escalate verbs to clusterroles rule

### DIFF
--- a/helm/templates/clusterrole.yaml
+++ b/helm/templates/clusterrole.yaml
@@ -113,7 +113,9 @@ rules:
   - clusterrolebindings
   - clusterroles
   verbs:
+  - bind
   - create
+  - escalate
   - get
   - patch
 - apiGroups:


### PR DESCRIPTION
## Summary

- Adds `bind` and `escalate` verbs to the `clusterrolebindings`/`clusterroles` rule in `helm/templates/clusterrole.yaml` under the `rancher.enabled` gate
- Syncs Helm ClusterRole with the security-approved `config/rbac/role.yaml` baseline (updated by PR #459)
- Fixes RancherSession failure at manifest apply time due to Kubernetes escalation prevention

## Test plan

- [ ] Deploy via Helm with `rancher.enabled=true` on a k3s cluster
- [ ] Trigger Rancher connect workflow
- [ ] Confirm `kubectl describe ranchersession -n losant-system` shows Phase: Connected (not ManifestApplyFailed)
- [ ] Confirm no other verbs were added beyond `bind` and `escalate`

Closes #463

🤖 Generated with [Claude Code](https://claude.ai/claude-code)