### PR TITLE
feat(helm): add cluster-admin ClusterRoleBinding for Rancher import

### DIFF
--- a/helm/templates/clusterrolebinding-cluster-admin.yaml
+++ b/helm/templates/clusterrolebinding-cluster-admin.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.rancher.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "losant-device.fullname" . }}-cluster-admin
+  labels:
+    {{- include "losant-device.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "losant-device.serviceAccountName" . }}
+    namespace: {{ .Values.namespace.name }}
+{{- end }}


### PR DESCRIPTION
## Summary

- Adds `helm/templates/clusterrolebinding-cluster-admin.yaml` gated by `rancher.enabled && rbac.create`
- Provides Helm parity with `config/rbac/cluster_admin_binding.yaml` added in PR #467
- Follows security Option A (permanent cluster-admin binding) approved in #465

## Test plan

- [ ] `helm template . --set rancher.enabled=true` includes the new ClusterRoleBinding
- [ ] `helm template . --set rancher.enabled=false` omits the ClusterRoleBinding
- [ ] Binding references `cluster-admin` ClusterRole and the controller ServiceAccount

Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)