### PR TITLE
refactor(controller): remove escalate/bind RBAC markers from ranchersession

### DIFF
--- a/internal/controller/ranchersession_controller.go
+++ b/internal/controller/ranchersession_controller.go
@@ -56,8 +56,6 @@ const (
 	rancherConditionAPIReachable = "RancherAPIReachable"
 )
 
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind;create;escalate;get;patch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create;get;patch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=create;get;patch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=create;get;patch
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=create;delete;get;patch


### PR DESCRIPTION
## Summary

- Removes the two `+kubebuilder:rbac` markers for `rbac.authorization.k8s.io` clusterroles and clusterrolebindings from `ranchersession_controller.go`
- These markers were written for the rejected Option B (transient per-session SA with escalate/bind). Option A (permanent cluster-admin ClusterRoleBinding) was adopted in PR #467, making these rules redundant
- `make manifests` no longer generates the `rbac.authorization.k8s.io` rules section in `role.yaml`, confirmed locally
- `role.yaml` is NOT committed here — security handles the follow-up cleanup

Closes #469

## Test plan

- [x] `make test` passes (all packages green)
- [x] `make manifests` confirmed to no longer emit `rbac.authorization.k8s.io` clusterroles/clusterrolebindings rules
- [x] `git diff --exit-code config/rbac/role.yaml` clean after `git checkout config/rbac/role.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)