### PR TITLE
feat(controller): add last_sync_epoch, rancher_connected, rancher_session_phase attributes

### DIFF
--- a/internal/controller/losantsync_controller.go
+++ b/internal/controller/losantsync_controller.go
@@ -56,6 +56,7 @@ type LosantSyncReconciler struct {
 
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=losant.io,resources=losantsyncs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=losant.io,resources=ranchersessions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list;watch
@@ -211,9 +212,14 @@ func (r *LosantSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Step 6: report cluster state to GEA.
+	rancherConnected, rancherPhase := r.rancherSessionStatus(ctx, ls.Namespace)
+	clusterAttrs := clusterAttributes(clusterSnapshot)
+	clusterAttrs["last_sync_epoch"] = time.Now().Unix()
+	clusterAttrs["rancher_connected"] = rancherConnected
+	clusterAttrs["rancher_session_phase"] = rancherPhase
 	if err := gc.ReportState(ctx, gea.StatePayload{
 		DeviceID:   clusterDeviceID,
-		Attributes: clusterAttributes(clusterSnapshot),
+		Attributes: clusterAttrs,
 	}); err != nil {
 		logger.Info("GEA unreachable, will retry", "error", err.Error())
 		return r.setDegraded(ctx, &ls, "GEAReachable", "GEAUnreachable", err.Error())
@@ -387,6 +393,21 @@ func (r *LosantSyncReconciler) healthSnapshot() (monitor.ClusterHealth, map[stri
 		return monitor.ClusterHealth{}, map[string]monitor.NodeHealth{}
 	}
 	return r.HealthStore.Snapshot()
+}
+
+// rancherSessionStatus lists RancherSession objects in namespace and returns the aggregate
+// connected flag and phase string. Returns (false, "None") when no RancherSession CRs exist.
+func (r *LosantSyncReconciler) rancherSessionStatus(ctx context.Context, namespace string) (bool, string) {
+	var sessions losantv1alpha1.RancherSessionList
+	if err := r.List(ctx, &sessions, client.InNamespace(namespace)); err != nil || len(sessions.Items) == 0 {
+		return false, "None"
+	}
+	for _, s := range sessions.Items {
+		if s.Status.Phase == losantv1alpha1.RancherSessionPhaseConnected {
+			return true, string(losantv1alpha1.RancherSessionPhaseConnected)
+		}
+	}
+	return false, string(sessions.Items[0].Status.Phase)
 }
 
 // nextScheduleAndDuration computes the next sync time and the requeue duration

--- a/internal/controller/losantsync_controller_test.go
+++ b/internal/controller/losantsync_controller_test.go
@@ -1336,3 +1336,128 @@ func TestWorkflowDeployments_MultipleFlows_OnlyStaleReleased(t *testing.T) {
 		t.Errorf("ReleaseWorkflow called for wrong flow: got %q, want flow-stale", call.FlowID)
 	}
 }
+
+// --- rancherSessionStatus and last_sync_epoch ---
+
+// TestRancherSessionStatus_NoSession verifies that when no RancherSession CRs exist,
+// the cluster GEA payload reports rancher_connected=false and rancher_session_phase="None".
+func TestRancherSessionStatus_NoSession(t *testing.T) {
+	ls := baseLS("rancher-no-session")
+	mg := gea.NewMockClient()
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, losant.NewMockClient(), mg, monitor.NewHealthStore())
+
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_connected", false)
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_session_phase", "None")
+}
+
+// TestRancherSessionStatus_Connected verifies that a Connected RancherSession causes
+// the cluster GEA payload to report rancher_connected=true and rancher_session_phase="Connected".
+func TestRancherSessionStatus_Connected(t *testing.T) {
+	ls := baseLS("rancher-connected")
+	session := &losantv1alpha1.RancherSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "rs-connected"},
+		Status: losantv1alpha1.RancherSessionStatus{
+			Phase: losantv1alpha1.RancherSessionPhaseConnected,
+		},
+	}
+	mg := gea.NewMockClient()
+	c := buildClient(ls, credsSecret(), session)
+	r := newReconciler(c, losant.NewMockClient(), mg, monitor.NewHealthStore())
+
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_connected", true)
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_session_phase", "Connected")
+}
+
+// TestRancherSessionStatus_Disconnected verifies that a non-Connected RancherSession causes
+// the cluster GEA payload to report rancher_connected=false and the actual phase string.
+func TestRancherSessionStatus_Disconnected(t *testing.T) {
+	ls := baseLS("rancher-disconnected")
+	session := &losantv1alpha1.RancherSession{
+		ObjectMeta: metav1.ObjectMeta{Name: "rs-disconnected"},
+		Status: losantv1alpha1.RancherSessionStatus{
+			Phase: losantv1alpha1.RancherSessionPhaseDisconnected,
+		},
+	}
+	mg := gea.NewMockClient()
+	c := buildClient(ls, credsSecret(), session)
+	r := newReconciler(c, losant.NewMockClient(), mg, monitor.NewHealthStore())
+
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_connected", false)
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_session_phase", "Disconnected")
+}
+
+// TestRancherSessionStatus_MultipleConnectedWins verifies that when multiple RancherSession CRs
+// exist and at least one is Connected, the payload reports rancher_connected=true and
+// rancher_session_phase="Connected".
+func TestRancherSessionStatus_MultipleConnectedWins(t *testing.T) {
+	ls := baseLS("rancher-multi")
+	objs := []client.Object{
+		ls,
+		credsSecret(),
+		&losantv1alpha1.RancherSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "rs-connecting"},
+			Status:     losantv1alpha1.RancherSessionStatus{Phase: losantv1alpha1.RancherSessionPhaseConnecting},
+		},
+		&losantv1alpha1.RancherSession{
+			ObjectMeta: metav1.ObjectMeta{Name: "rs-connected"},
+			Status:     losantv1alpha1.RancherSessionStatus{Phase: losantv1alpha1.RancherSessionPhaseConnected},
+		},
+	}
+	mg := gea.NewMockClient()
+	c := buildClient(objs...)
+	r := newReconciler(c, losant.NewMockClient(), mg, monitor.NewHealthStore())
+
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_connected", true)
+	mg.AssertPayloadContains(t, "mock-cluster-device-id", "rancher_session_phase", "Connected")
+}
+
+// TestClusterAttributesIncludesSyncEpoch verifies that the cluster GEA state payload
+// contains a last_sync_epoch value within the test's execution window.
+func TestClusterAttributesIncludesSyncEpoch(t *testing.T) {
+	ls := baseLS("sync-epoch")
+	mg := gea.NewMockClient()
+	c := buildClient(ls, credsSecret())
+	r := newReconciler(c, losant.NewMockClient(), mg, monitor.NewHealthStore())
+
+	before := time.Now().Unix()
+	if _, err := reconcileTwice(t, r, reqFor(ls.Name)); err != nil {
+		t.Fatalf("reconcile error: %v", err)
+	}
+	after := time.Now().Unix()
+
+	var clusterPayload *gea.StatePayload
+	for i := range mg.Calls {
+		if mg.Calls[i].DeviceID == "mock-cluster-device-id" {
+			p := mg.Calls[i]
+			clusterPayload = &p
+			break
+		}
+	}
+	if clusterPayload == nil {
+		t.Fatal("no GEA ReportState call found for cluster device")
+	}
+	epoch, ok := clusterPayload.Attributes["last_sync_epoch"]
+	if !ok {
+		t.Fatal("cluster state payload missing last_sync_epoch attribute")
+	}
+	epochInt, ok := epoch.(int64)
+	if !ok {
+		t.Fatalf("last_sync_epoch type: got %T, want int64", epoch)
+	}
+	if epochInt < before || epochInt > after {
+		t.Errorf("last_sync_epoch %d not in expected range [%d, %d]", epochInt, before, after)
+	}
+}

--- a/internal/losant/client.go
+++ b/internal/losant/client.go
@@ -416,6 +416,9 @@ func clusterDeviceAttributes() []DeviceAttribute {
 		{Name: "degraded_pvcs", DataType: "number"},
 		{Name: "coredns_healthy", DataType: "boolean"},
 		{Name: "event_warnings", DataType: "number"},
+		{Name: "last_sync_epoch", DataType: "number"},
+		{Name: "rancher_connected", DataType: "boolean"},
+		{Name: "rancher_session_phase", DataType: "string"},
 	}
 }
 

--- a/internal/losant/client_test.go
+++ b/internal/losant/client_test.go
@@ -704,8 +704,8 @@ func TestEnsureClusterDevice_Created_HasAttributes(t *testing.T) {
 	if !ok {
 		t.Fatalf("POST body missing 'attributes' field; body: %v", postBody)
 	}
-	if len(attrs) != 13 {
-		t.Errorf("cluster attribute count: got %d, want 13", len(attrs))
+	if len(attrs) != 16 {
+		t.Errorf("cluster attribute count: got %d, want 16", len(attrs))
 	}
 }
 
@@ -760,8 +760,8 @@ func TestEnsureClusterDevice_Found_PatchHasAttributes(t *testing.T) {
 		t.Fatal("PATCH handler was not called")
 	}
 	attrs, ok := patchBody["attributes"].([]interface{})
-	if !ok || len(attrs) != 13 {
-		t.Errorf("PATCH body: expected 13 cluster attributes, got: %v", patchBody["attributes"])
+	if !ok || len(attrs) != 16 {
+		t.Errorf("PATCH body: expected 16 cluster attributes, got: %v", patchBody["attributes"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `last_sync_epoch` (number), `rancher_connected` (boolean), and `rancher_session_phase` (string) to the cluster edgeCompute device's GEA state payload and Losant provisioning schema
- Adds `rancherSessionStatus()` helper on `LosantSyncReconciler` to query `RancherSession` CRs in the same namespace at each sync cycle
- Adds `// +kubebuilder:rbac:groups=losant.io,resources=ranchersessions,verbs=get;list;watch` marker (within the security-approved baseline; no `role.yaml` drift)

## Test plan

- [ ] Test engineer to update `TestEnsureClusterDevice_Created_HasAttributes` and `TestEnsureClusterDevice_Found_PatchHasAttributes` in `internal/losant/client_test.go` to expect 16 attributes instead of 13
- [ ] Test engineer to add unit tests for `rancherSessionStatus()` covering: no RancherSession CR (returns false/"None"), one Connected session, one non-Connected session, multiple sessions where one is Connected

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)