### PR TITLE
security(deps): upgrade Go toolchain from 1.26.3 to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mak3r/losant-device
 
-go 1.26.3
+go 1.26.4
 
 godebug default=go1.26
 


### PR DESCRIPTION
## Summary

- Bumps `go.mod` from `go 1.26.3` to `go 1.26.4`
- Resolves three stdlib CVEs fixed in go1.26.4:
  - GO-2026-5039 — `net/textproto`: arbitrary inputs included in errors without escaping
  - GO-2026-5038 — `mime`: quadratic complexity in `WordDecoder.DecodeHeader`
  - GO-2026-5037 — `crypto/x509`: inefficient candidate hostname parsing

## Notes

The `dockerfile-go-version` CI check enforces that the `FROM golang:` line in `Dockerfile` matches the `go` directive in `go.mod`. A companion gitops-manager issue must update the Dockerfile before or alongside this PR to keep CI green.

Closes #479

## Test plan

- [x] `make test` passes with go1.26.4 toolchain
- [ ] `govulncheck ./...` exits 0 (requires go1.26.4 toolchain in CI)
- [ ] Coordinate merge with gitops-manager Dockerfile update

🤖 Generated with [Claude Code](https://claude.com/claude-code)