### PR TITLE
security(dockerfile): upgrade Go builder to golang:1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
 ARG TARGETOS TARGETARCH
 WORKDIR /workspace
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary

- Upgrades the Dockerfile builder stage from `golang:1.26.3` to `golang:1.26.4`
- Eliminates CVEs GO-2026-5037, GO-2026-5038, GO-2026-5039 (all fixed in go1.26.4)

## Coordination Required

The `dockerfile-go-version` CI check enforces that the `FROM golang:` version in `Dockerfile` matches the `go` directive in `go.mod`. This PR changes the Dockerfile to `golang:1.26.4`, but `go.mod` is still at `go 1.26.3` on `develop`.

**This PR must be merged after or together with the developer's go.mod upgrade (issue #479).** Once the developer's change lands on `develop`, rebase this branch and the CI check will pass.

Closes #480
Depends on: #479

## Test plan

- [ ] Confirm developer PR for #479 (go.mod `go 1.26.4`) is merged to `develop` first
- [ ] Rebase this branch on updated `develop`
- [ ] Verify `dockerfile-go-version` CI check passes (both versions equal `1.26.4`)
- [ ] Verify vulnerability scan shows no GO-2026-503x findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)