### PR TITLE
security(gitleaks): allowlist abcdef hex placeholder in docs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,6 +25,9 @@ regexes = [
   '''fake-.*-secret''',
   '''test-access-key''',
   '''test-access-secret''',
+  # Common hex/alphanumeric placeholder strings used in documentation examples
+  # e.g. "key": "abcdef123456" in JSON snippets — low entropy, clearly illustrative
+  '''(?i)abcdef[0-9a-f]+''',
 ]
 
 [[rules]]


### PR DESCRIPTION
## Summary

- Extends the `docs/.*` path allowlist in `.gitleaks.toml` with a regex matching `abcdef`-prefixed hex strings (`(?i)abcdef[0-9a-f]+`)
- Fixes the false-positive Gitleaks failure on PR #488 (`docs/setup/5b-dashboards.md:77` — `"key": "abcdef123456"` in a JSON example)
- No application logic or RBAC changes

## Test plan

- [ ] Confirm `Secret Scanning (Gitleaks)` check passes on this PR
- [ ] Confirm PR #488 Gitleaks check clears after this merges to `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)